### PR TITLE
Pull auditor tasks from server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 # firebase
 .firebaserc

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -39,6 +39,7 @@ export type ClaimTask = {
   patientFirstName: string;
   patientLastName: string;
   patientID?: string;
+  phone?: string;
   item: string;
   totalCost: number;
   claimedCost: number;
@@ -115,6 +116,7 @@ async function loadAuditorTasks(): Promise<Task[]> {
       patientFirstName: d["g2:A10 First Name"],
       patientLastName: d["g2:A11 Last Name"],
       patientID: d["g4:B02.1 ID number on voucher"],
+      phone: d["g2:A14 Phone Number"],
       photoIDUri: d["g4:B03.1 Photo of ID card"],
       photoMedUri: d["g5:B04 (Medication)"],
       photoMedBatchUri: d["g5:B05 (Medication batch)"],

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -1,5 +1,6 @@
 import firebase from "firebase/app";
 import "firebase/auth";
+import "firebase/firestore";
 
 const FIREBASE_CONFIG = {
   apiKey: "AIzaSyCspibVcd3GcAk01xHndZEJX8zuxwPIt-Y",
@@ -9,6 +10,12 @@ const FIREBASE_CONFIG = {
   storageBucket: "flows-app-staging.appspot.com",
   messagingSenderId: "785605389839",
   appId: "1:785605389839:web:dedec19abb81b7df8a3d7a"
+};
+const AUDITOR_TODO_COLLECTION = "auditor_todo";
+type AuditorTodo = {
+  batchID: string;
+  pharmacyID: string;
+  data: any;
 };
 
 export enum UserRole {
@@ -70,9 +77,7 @@ export async function userRoles(): Promise<UserRole[]> {
 export async function tasksForRole(role: UserRole): Promise<Task[]> {
   switch (role) {
     case UserRole.AUDITOR:
-      return auditorSampleTasks.map(c => {
-        return { ...c, changes: [] };
-      });
+      return loadAuditorTasks();
     case UserRole.PAYOR:
       return [
         {
@@ -89,6 +94,33 @@ export async function tasksForRole(role: UserRole): Promise<Task[]> {
         }
       ];
   }
+}
+
+async function loadAuditorTasks(): Promise<Task[]> {
+  const todoSnapshot = await firebase
+    .firestore()
+    .collection(AUDITOR_TODO_COLLECTION)
+    .get();
+  const todos = todoSnapshot.docs.map(
+    doc => (doc.data() as unknown) as AuditorTodo
+  );
+
+  return todos.map(t => {
+    const d = t.data;
+    return {
+      patientFirstName: d["g2:A10 First Name"],
+      patientLastName: d["g2:A11 Last Name"],
+      item: d["Type received"],
+      totalCost: d["Total med price covered by SPIDER"],
+      claimedCost: d["Total reimbursement"],
+      timestamp: new Date(d["YYYY"], d["MM"], d["DD"]).getTime(),
+      site: {
+        name: d["g3:B01 Pharmacy name"],
+        phone: "+254 867 5309"
+      },
+      changes: []
+    };
+  });
 }
 
 const auditorSampleTasks: ClaimTask[] = [

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -38,10 +38,14 @@ export type Site = {
 export type ClaimTask = {
   patientFirstName: string;
   patientLastName: string;
+  patientID?: string;
   item: string;
   totalCost: number;
   claimedCost: number;
   site: Site;
+  photoIDUri?: string;
+  photoMedUri?: string;
+  photoMedBatchUri?: string;
   timestamp: number;
   notes?: string;
 };
@@ -110,6 +114,10 @@ async function loadAuditorTasks(): Promise<Task[]> {
     return {
       patientFirstName: d["g2:A10 First Name"],
       patientLastName: d["g2:A11 Last Name"],
+      patientID: d["g4:B02.1 ID number on voucher"],
+      photoIDUri: d["g4:B03.1 Photo of ID card"],
+      photoMedUri: d["g5:B04 (Medication)"],
+      photoMedBatchUri: d["g5:B05 (Medication batch)"],
       item: d["Type received"],
       totalCost: d["Total med price covered by SPIDER"],
       claimedCost: d["Total reimbursement"],


### PR DESCRIPTION
We can now pull auditor tasks directly from the server, since CSV upload is working.  As we develop Details View a bit more, we'll need to pull more and more data into the actual ClaimTask;  but for now, this replaces our test data with data that came from a CSV.

I haven't updated the Payor view with this data because we'd likely want to enable a real edit flow instead of doing that (i.e. we'll likely want to implement the "click Approve" functionality in order to populate the Payor view with real data).

Here's the data they gave us, pulled from Firestore:
![image](https://user-images.githubusercontent.com/42978089/65811014-1c0ce900-e167-11e9-8e76-b3bff1441b27.png)
