### PR TITLE
Group claims by pharmacy

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -86,19 +86,17 @@ async function completeCSVProcessing(cache: any[]) {
 
   // Now generate Auditor work items representing each sampled row.  No need to
   // await this stuff either -- we just let each one happen whenever they do.
-  sampledRowsByPharmacy.forEach(pharm => {
+  sampledRowsByPharmacy.forEach(async pharm => {
     console.log(`Pharmacy ${pharm.key} has ${pharm.values.length} rows`);
-    pharm.values.forEach(row =>
-      admin
-        .firestore()
-        .collection(AUDITOR_TODO_COLLECTION)
-        .doc()
-        .set({
-          batchID,
-          pharmacyID: pharm.key,
-          data: row
-        })
-    );
+    await admin
+      .firestore()
+      .collection(AUDITOR_TODO_COLLECTION)
+      .doc()
+      .set({
+        batchID,
+        pharmacyID: pharm.key,
+        data: pharm.values
+      })
   });
   console.log(
     `Seem to have processed ${sampledRowsByPharmacy.length} pharmacies`

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -84,9 +84,8 @@ async function completeCSVProcessing(cache: any[]) {
     };
   });
 
-  // Now generate Auditor work items representing each sampled row.  No need to
-  // await this stuff either -- we just let each one happen whenever they do.
-  sampledRowsByPharmacy.forEach(async pharm => {
+  // Now generate Auditor work items representing each sampled row.
+  await Promise.all(sampledRowsByPharmacy.map(async pharm => {
     console.log(`Pharmacy ${pharm.key} has ${pharm.values.length} rows`);
     await admin
       .firestore()
@@ -97,7 +96,7 @@ async function completeCSVProcessing(cache: any[]) {
         pharmacyID: pharm.key,
         data: pharm.values
       })
-  });
+  }));
   console.log(
     `Seem to have processed ${sampledRowsByPharmacy.length} pharmacies`
   );

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -47,12 +47,20 @@ class MainView extends React.Component<Props, State> {
     const claim = task as ClaimTask;
     const previewName =
       "mainview_task_preview" + (isSelected ? " selected" : "");
+    const claimAmounts = claim.entries.map(entry => {
+      return entry.claimedCost;
+    });
+    const claimsTotal = claimAmounts.reduce(
+      (sum, claimedCost) => sum + claimedCost
+    );
     return (
       <div className={previewName}>
         <div className="mainview_preview_header">
           <span>{claim.site.name}</span>
           <span>{claim.entries.length} Entries</span>
         </div>
+        <div>{"Claims to Review: " + claim.entries.length}</div>
+        <div>{"Total Reimbursement: " + claimsTotal.toFixed(2) + " KSh"}</div>
       </div>
     );
   };

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -124,7 +124,9 @@ class MainView extends React.Component<Props, State> {
   _renderReimbursementDetails = (task: Task) => {
     const reimbursement = task as ReimbursementTask;
     const claim = reimbursement.claim as ClaimTask;
-    if (!reimbursement || !claim || !claim.entries) return null;
+    if (!reimbursement || !claim || !claim.entries) {
+      return null;
+    }
     const claimAmounts = claim.entries.map(entry => {
       return entry.claimedCost;
     });

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -129,8 +129,8 @@ async function loadAuditorTasks(): Promise<Task[]> {
       photoMedUri: d["g5:B04 (Medication)"],
       photoMedBatchUri: d["g5:B05 (Medication batch)"],
       item: d["Type received"],
-      totalCost: d["Total med price covered by SPIDER"],
-      claimedCost: d["Total reimbursement"],
+      totalCost: parseFloat(d["Total med price covered by SPIDER"]),
+      claimedCost: parseFloat(d["Total reimbursement"]),
       timestamp: new Date(d["YYYY"], d["MM"], d["DD"]).getTime(),
     }));
     return {

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -137,7 +137,6 @@ async function loadAuditorTasks(): Promise<Task[]> {
       entries: patients,
       site: {
         name: d[0]["g3:B01 Pharmacy name"],
-        phone: "+254 867 5309"
       },
       changes: []
     };


### PR DESCRIPTION
This PR modifies the function that parses CSVs to just create one task per pharmacy, with a sampled set of entries for that pharmacy included in the task, and updates the task list and details view for `ClaimTask` to render appropriately.

The task list entries are super barebones, we'll probably want to add more detail here (and presumably in real CSVs the "pharmacy name" column won't just be a number):
![image](https://user-images.githubusercontent.com/1070243/66008535-c9377800-e46b-11e9-87a1-76cec1f74e09.png)

The details might need to be collapsible or something:
![image](https://user-images.githubusercontent.com/1070243/66008576-f71cbc80-e46b-11e9-91dd-4ce91655a04c.png)
