### PR TITLE
Implement full task flow

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -65,6 +65,7 @@ exports.setRoles = functions.https.onCall(
 enum UserRole {
   AUDITOR = "Auditor",
   PAYOR = "Payor",
+  OPERATOR = "Operator",
   ADMIN = "Admin"
 }
 
@@ -148,18 +149,20 @@ async function completeCSVProcessing(cache: any[]) {
   });
 
   // Now generate Auditor work items representing each sampled row.
-  await Promise.all(sampledRowsByPharmacy.map(async pharm => {
-    console.log(`Pharmacy ${pharm.key} has ${pharm.values.length} rows`);
-    await admin
-      .firestore()
-      .collection(AUDITOR_TODO_COLLECTION)
-      .doc()
-      .set({
-        batchID,
-        pharmacyID: pharm.key,
-        data: pharm.values
-      })
-  }));
+  await Promise.all(
+    sampledRowsByPharmacy.map(async pharm => {
+      console.log(`Pharmacy ${pharm.key} has ${pharm.values.length} rows`);
+      await admin
+        .firestore()
+        .collection(AUDITOR_TODO_COLLECTION)
+        .doc()
+        .set({
+          batchID,
+          pharmacyID: pharm.key,
+          data: pharm.values
+        });
+    })
+  );
   console.log(
     `Seem to have processed ${sampledRowsByPharmacy.length} pharmacies`
   );

--- a/src/Components/LabelTextInput.tsx
+++ b/src/Components/LabelTextInput.tsx
@@ -3,6 +3,7 @@ import "./LabelTextInput.css";
 
 interface Props {
   label?: string;
+  defaultValue?: string;
   onTextChange: (text: string) => void;
 }
 
@@ -21,6 +22,7 @@ class LabelTextInput extends Component<Props> {
         )}
         <textarea
           className="labeltextinput_input"
+          defaultValue={this.props.defaultValue}
           onChange={this._onTextChange}
         />
       </div>

--- a/src/Components/LabelWrapper.css
+++ b/src/Components/LabelWrapper.css
@@ -1,10 +1,6 @@
 .labelwrapper_container {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
   margin: 5px;
   border: 1px solid black;
-  min-width: 250px;
 }
 
 .labelwrapper_header {

--- a/src/Screens/AdminPanel.tsx
+++ b/src/Screens/AdminPanel.tsx
@@ -8,6 +8,7 @@ type RoleMap = {
 const NO_ROLES_MAP: RoleMap = {
   Auditor: false,
   Payor: false,
+  Operator: false,
   Admin: false
 };
 

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -148,14 +148,14 @@ class AuditorPanel extends React.Component<Props, State> {
 
   render() {
     return (
-      <div>
+      <div className="mainview_content">
         <TaskList
           onSelect={this._onTaskSelect}
           tasks={this.state.tasks}
           renderItem={this._renderTaskListClaim}
           className="mainview_tasklist"
         />
-        <div style={{ width: "100%" }}>
+        <div>
           {this.state.selectedTaskIndex >= 0 &&
             this._renderClaimDetails(
               this.state.tasks[this.state.selectedTaskIndex]

--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -2,8 +2,13 @@
   margin: 16px;
 }
 
+.mainview_content {
+  display: flex;
+  width: 100%;
+}
+
 .mainview_tasklist {
-  width: 250px;
+  min-width: 300px;
 }
 
 .mainview_task_preview {

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -9,6 +9,7 @@ import "./MainView.css";
 import AuditorPanel from "./AuditorPanel";
 import PayorPanel from "./PayorPanel";
 import AdminPanel from "./AdminPanel";
+import OperatorPanel from "./OperatorPanel";
 
 type Props = {};
 type State = {
@@ -18,6 +19,7 @@ type State = {
 const RoleToPanelMap = {
   Auditor: AuditorPanel,
   Payor: PayorPanel,
+  Operator: OperatorPanel,
   Admin: AdminPanel
 };
 
@@ -25,7 +27,6 @@ class MainView extends React.Component<Props, State> {
   state: State = {
     roles: []
   };
-
   async componentDidMount() {
     const roles = await userRoles();
     this.setState({ roles });

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -8,10 +8,9 @@ import TextItem from "../Components/TextItem";
 import {
   ClaimEntry,
   Task,
-  declineAudit,
-  loadAuditorTasks,
   getLatestTaskNote,
-  saveAuditorApprovedTask
+  loadOperatorTasks,
+  saveOperatorCompletedTask
 } from "../store/corestore";
 import "./MainView.css";
 import "react-tabs/style/react-tabs.css";
@@ -24,7 +23,7 @@ type State = {
   notes: string;
 };
 
-class AuditorPanel extends React.Component<Props, State> {
+class OperatorPanel extends React.Component<Props, State> {
   state: State = {
     tasks: [],
     selectedTaskIndex: -1,
@@ -32,11 +31,11 @@ class AuditorPanel extends React.Component<Props, State> {
   };
 
   async componentDidMount() {
-    const tasks = await loadAuditorTasks();
+    const tasks = await loadOperatorTasks();
     this.setState({ tasks });
   }
 
-  _renderTaskListClaim = (task: Task, isSelected: boolean) => {
+  _renderTaskList = (task: Task, isSelected: boolean) => {
     const previewName =
       "mainview_task_preview" + (isSelected ? " selected" : "");
     const claimAmounts = task.entries.map(entry => {
@@ -61,17 +60,11 @@ class AuditorPanel extends React.Component<Props, State> {
     this.setState({ notes });
   };
 
-  _onApprove = async () => {
-    await saveAuditorApprovedTask(
+  _onCompleted = async () => {
+    await saveOperatorCompletedTask(
       this.state.tasks[this.state.selectedTaskIndex],
       this.state.notes
     );
-    this._removeSelectedTask();
-  };
-
-  _onDecline = async () => {
-    const task = this.state.tasks[this.state.selectedTaskIndex];
-    await declineAudit(task, this.state.notes);
     this._removeSelectedTask();
   };
 
@@ -109,7 +102,7 @@ class AuditorPanel extends React.Component<Props, State> {
       patientProps.length > 0 ? `(${patientProps.join(", ")})` : "";
 
     return (
-      <LabelWrapper key={entry.patientID}>
+      <LabelWrapper>
         <TextItem
           data={{ Date: new Date(entry.timestamp).toLocaleDateString() }}
         />
@@ -135,8 +128,7 @@ class AuditorPanel extends React.Component<Props, State> {
           defaultValue={getLatestTaskNote(task)}
         />
         <div className="mainview_button_row">
-          <Button label="Decline" onClick={this._onDecline} />
-          <Button label="Approve" onClick={this._onApprove} />
+          <Button label="Mark Completed" onClick={this._onCompleted} />
         </div>
       </LabelWrapper>
     );
@@ -152,7 +144,7 @@ class AuditorPanel extends React.Component<Props, State> {
         <TaskList
           onSelect={this._onTaskSelect}
           tasks={this.state.tasks}
-          renderItem={this._renderTaskListClaim}
+          renderItem={this._renderTaskList}
           className="mainview_tasklist"
         />
         <div style={{ width: "100%" }}>
@@ -166,4 +158,4 @@ class AuditorPanel extends React.Component<Props, State> {
   }
 }
 
-export default AuditorPanel;
+export default OperatorPanel;

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -140,14 +140,14 @@ class OperatorPanel extends React.Component<Props, State> {
 
   render() {
     return (
-      <div>
+      <div className="mainview_content">
         <TaskList
           onSelect={this._onTaskSelect}
           tasks={this.state.tasks}
           renderItem={this._renderTaskList}
           className="mainview_tasklist"
         />
-        <div style={{ width: "100%" }}>
+        <div>
           {this.state.selectedTaskIndex >= 0 &&
             this._renderClaimDetails(
               this.state.tasks[this.state.selectedTaskIndex]

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -50,7 +50,7 @@ class PayorPanel extends React.Component<Props, State> {
         <div className="mainview_preview_header">
           <span>{task.site.name}</span>
         </div>
-        <div>{"Total Reimbursement: " + claimsTotal + " KSh"}</div>
+        <div>{"Total Reimbursement: " + claimsTotal.toFixed(2) + " KSh"}</div>
       </div>
     );
   };
@@ -106,7 +106,7 @@ class PayorPanel extends React.Component<Props, State> {
         <TextItem data={{ Pharmacy: task.site.name }} />
         {!!task.site.phone && <TextItem data={{ Phone: task.site.phone }} />}
         <TextItem
-          data={{ "Total Reimbursement": claimsTotal.toString() + "KSh" }}
+          data={{ "Total Reimbursement": claimsTotal.toFixed(2) + " KSh" }}
         />
         <DataTable data={cleanedData} />
         <LabelTextInput
@@ -127,7 +127,7 @@ class PayorPanel extends React.Component<Props, State> {
 
   render() {
     return (
-      <div>
+      <div className="mainview_content">
         <TaskList
           onSelect={this._onTaskSelect}
           tasks={this.state.tasks}

--- a/src/africas-talking-key.json
+++ b/src/africas-talking-key.json
@@ -1,0 +1,4 @@
+{
+  "apiKey": "f4cf730b2f7a9b07e165fbaa5b4687d527d7d9171f368b90d9c26c3e5fe45a0a",
+  "username": "sandbox"
+}


### PR DESCRIPTION
This integrates an Operator tab, and also completes the entire workflow (all the way through to server edits).  Key changes:

* New Role of Operator (the person who calls pharmacies and follows up)
* New OperatorPanel
* Complete flow stored in Firebase.  If an Auditor or Payor declines, the task ends up at the Operator showing their latest notes.  If an Operator completes their work, the task moves to the Payor.  If a Payor marks payment complete, we store the completed task in the payor_complete_tasks folder in Firestore.
* Data model simplification:  since we operate on pharmacies as a basic unit, it seemed simpler just to have Tasks be ClaimTasks.  In other words, a task moves from person to person... but there aren't different types of tasks.  I've also moved Notes into the TaskChangeMetadata, which is debatable;  but the thought was that every step of the way, someone in a role should be able to add a Note to explain their action/change.

A task that was Declined to the operator:
![image](https://user-images.githubusercontent.com/42978089/66090910-39acca80-e53a-11e9-8b02-7d4b458476fe.png)

And then when that Operator completed their follow-up:
![image](https://user-images.githubusercontent.com/42978089/66090926-4af5d700-e53a-11e9-8f3e-3f05ad5e0b39.png)

And finally, after the payor marked that task Complete:
![image](https://user-images.githubusercontent.com/42978089/66090934-52b57b80-e53a-11e9-9f51-61ae315e7b57.png)

