### PR TITLE
Show other active users

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
     "@types/react-tabs": "^2.3.1",
+    "@types/react-tooltip": "^3.9.3",
     "firebase": "^6.6.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-firebaseui": "^4.0.0",
     "react-scripts": "3.1.1",
     "react-tabs": "^3.0.0",
+    "react-tooltip": "^3.11.1",
     "typescript": "^3.6.3"
   },
   "scripts": {

--- a/src/Components/TaskList.css
+++ b/src/Components/TaskList.css
@@ -7,3 +7,9 @@
   height: 24px;
   line-height: 24px;
 }
+
+.tasklist_active {
+  outline-color: orange;
+  outline-style: solid;
+  outline-width: 4px;
+}

--- a/src/Components/TaskList.tsx
+++ b/src/Components/TaskList.tsx
@@ -1,7 +1,17 @@
 import React from "react";
-import { Task } from "../store/corestore";
+import {
+  Task,
+  ActiveTask,
+  dateFromServerTimestamp,
+  subscribeActiveTasks,
+  logActiveTaskView,
+  getBestUserName
+} from "../store/corestore";
 import LabelWrapper from "./LabelWrapper";
 import "./TaskList.css";
+import ReactTooltip from "react-tooltip";
+
+const MAX_ACTIVE_MSEC = 5 * 60 * 1000; // 5 mins is considered "active"
 
 type Props = {
   tasks: Task[];
@@ -12,12 +22,28 @@ type Props = {
 
 type State = {
   selectedIndex: number | null;
+  activeTasks: ActiveTask[];
 };
 
 class TaskList extends React.Component<Props, State> {
   state: State = {
-    selectedIndex: null
+    selectedIndex: null,
+    activeTasks: []
   };
+  _unsubscribeActives: (() => void) | null = null;
+
+  componentDidMount() {
+    this._unsubscribeActives = subscribeActiveTasks(tasks =>
+      this.setState({ activeTasks: tasks })
+    );
+  }
+
+  componentWillUnmount() {
+    if (this._unsubscribeActives) {
+      this._unsubscribeActives();
+      this._unsubscribeActives = null;
+    }
+  }
 
   _onItemPressed = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     const dataName = event.currentTarget.getAttribute("data-name");
@@ -32,20 +58,48 @@ class TaskList extends React.Component<Props, State> {
       this.props.onSelect(index);
     }
 
+    // Let this drift by without await because nothing after it depends on it
+    logActiveTaskView(this.props.tasks[index].id);
+
     this.setState({ selectedIndex: index });
   };
+
+  _isActiveTask(task: Task) {
+    const activeTask = this.state.activeTasks.find(t => t.id === task.id);
+    const recentlyActive =
+      activeTask &&
+      Date.now() - dateFromServerTimestamp(activeTask.since).getTime() <=
+        MAX_ACTIVE_MSEC;
+    if (recentlyActive && activeTask!.name !== getBestUserName()) {
+      return activeTask;
+    }
+    return null;
+  }
 
   render() {
     return (
       <LabelWrapper className={this.props.className} label={"Items to Review"}>
         <div>
           {this.props.tasks.map((task, index) => {
+            const activeTask = this._isActiveTask(task);
+            const activeClass = activeTask ? "tasklist_active" : undefined;
+            const activeDataTip = activeTask
+              ? `${activeTask!.name} also working on this task`
+              : undefined;
+
             return (
-              <div key={index} data-name={index} onClick={this._onItemPressed}>
+              <div
+                className={activeClass}
+                key={index}
+                data-tip={activeDataTip}
+                data-name={index}
+                onClick={this._onItemPressed}
+              >
                 {this.props.renderItem(
                   task,
                   index === this.state.selectedIndex
                 )}
+                <ReactTooltip key={activeDataTip} />
               </div>
             );
           })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,6 +1699,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-tooltip@^3.9.3":
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-tooltip/-/react-tooltip-3.9.3.tgz#2eb1e08e128bb691197c5c7f9063fda9ffd5ea42"
+  integrity sha512-X9xuVWlZTLUQadIIrf5MnMPo/FE8izJPRo6c6f+XUs8eIaQ2vj+5Qw4Ttw9bMUPrqImmsJp7o7FY4t1qHLFf4g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^16.9.2":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
@@ -2961,7 +2968,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.0:
+classnames@^2.2.0, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -8643,7 +8650,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.0, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8961,6 +8968,14 @@ react-tabs@^3.0.0:
   dependencies:
     classnames "^2.2.0"
     prop-types "^15.5.0"
+
+react-tooltip@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.11.1.tgz#7b4ce48ed26a46e996662b19a2afebbfd483513b"
+  integrity sha512-YCMVlEC2KuHIzOQhPplTK5jmBBwoL+PYJJdJKXj7M/h7oevupd/QSVq6z5U7/ehIGXyHsAqvwpdxexDfyQ0o3A==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react@^16.9.0:
   version "16.9.0"


### PR DESCRIPTION
In a nod to GDocs, this is a proposal for how we deal with multiple active users working in the same role.  TaskList now writes a little piece of data into Firestore whenever a user clicks on a Task.  Every TaskList subscribes to that collection of active task views, and highlights tasks which others are looking at via an on-hover tooltip.  An orange rectangle highlights any task that someone else is looking at simultaneously (within the last 5 mins).

Introduced `react-tooltip` for this instead of writing our own on-hover funniness.  But I'm open to other perspectives on that.

Note that we don't bother deleting stale ActiveTasks from the Firestore collection.  This is assumed to be ok with our very small user base.  At some later point, we can write some sort of cloud function that cron-jobs itself to remove stale ActiveTasks from the collection.

Here's what it looks like, when I hacked TaskList to even show my own view as active (i.e. the actual code in this PR wouldn't have highlighted a task when the user themselves is the active viewer):
![image](https://user-images.githubusercontent.com/42978089/66246838-49f4af00-e6cc-11e9-80cc-d17601091aa4.png)
