### PR TITLE
Add access rules for firestore

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -18,5 +18,8 @@
       "npm --prefix \"$RESOURCE_DIR\" run lint",
       "npm --prefix \"$RESOURCE_DIR\" run build"
     ]
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,5 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-    allow read, write: if request.auth.token.roles.hasAny(['Admin'])
     match /auditor_todo/{docId} {
       allow read, write: if request.auth.token.roles.hasAny(['Auditor'])
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,19 @@
+service cloud.firestore {
+  match /databases/{database}/documents {
+    allow read, write: if request.auth.token.roles.hasAny(['Admin'])
+    match /auditor_todo/{docId} {
+      allow read, write: if request.auth.token.roles.hasAny(['Auditor'])
+    }
+    match /payor_task/{docId} {
+      allow write: if request.auth.token.roles.hasAny(['Auditor'])
+      allow read, write: if request.auth.token.roles.hasAny(['Payor'])
+    }
+    match /payment_complete_task/{docId} {
+      allow write: if request.auth.token.roles.hasAny(['Payor'])
+    }
+    match /operator_task/{docId} {
+      allow write: if request.auth.token.roles.hasAny(['Auditor', 'Payor'])
+      allow read, write: if request.auth.token.roles.hasAny(['Operator'])
+    }
+  }
+}


### PR DESCRIPTION
Provide read+write access to your own tasks, and write access to the "next" role's tasks.

Should admins have access to everything, or are they supposed to be strictly for setting other users' roles?