### PR TITLE
Revoke auth tokens when updating user capabilities

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -112,6 +112,7 @@ async function setRoles(email: string, roles: UserRole[]): Promise<CallResult> {
   }
 
   await admin.auth().setCustomUserClaims(user.uid, { roles });
+  await admin.auth().revokeRefreshTokens(user.uid);
   return {
     result: "Roles successfully set for " + email + ": " + JSON.stringify(roles)
   };


### PR DESCRIPTION
When an admin changes a user's capabilities, we now revoke their auth token so that they get refreshed capabilities the next time they refresh the page.

Tested this with @audererob, and it seems to work.