### PR TITLE
Allow everyone to access actively viewed doc ids

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,5 +1,8 @@
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /actively_viewed_tasks/{docId} {
+      allow read, write: if true
+    }
     match /auditor_todo/{docId} {
       allow read, write: if request.auth.token.roles.hasAny(['Auditor'])
     }


### PR DESCRIPTION
The actively viewed doc feature that Philip added conflicted with the backend access restrictions I added, so we've been getting this error on every tab:
![image](https://user-images.githubusercontent.com/1070243/66675520-53c16980-ec1a-11e9-8481-11f7053be9c5.png)

This PR grants everyone access to the `/actively_viewed_tasks/` collection to fix that error.