### PR TITLE
Introduce remote config and make payments configurable

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,5 +21,8 @@ service cloud.firestore {
     match /rejected_task/{docId} {
       allow read, write: if request.auth.token.roles.hasAny(['Auditor', 'Operator'])
     }
+    match /metadata/remoteConfig {
+      allow read: if true;
+    }
   }
 }

--- a/src/store/remoteconfig.ts
+++ b/src/store/remoteconfig.ts
@@ -1,0 +1,38 @@
+import firebase from "firebase/app";
+import "firebase/firestore";
+
+const REFRESH_MSEC = 60 * 60 * 1000; // Refresh settings once an hour
+
+type Config = {
+  enableRealPayments: boolean;
+};
+
+const DEFAULT_CONFIG: Config = {
+  enableRealPayments: false
+};
+
+let lastAccessTime: number = 0;
+let config: Config = DEFAULT_CONFIG;
+
+export async function getConfig(key: string) {
+  if (Date.now() - lastAccessTime >= REFRESH_MSEC) {
+    const snap = await firebase
+      .firestore()
+      .collection("metadata")
+      .doc("remoteConfig")
+      .get();
+
+    if (snap.exists) {
+      config = snap.data() as Config;
+    } else {
+      console.log(
+        "Didn't find /metadata/remoteConfig on server. Using defaults."
+      );
+    }
+  }
+  if (key in config) {
+    // @ts-ignore
+    return config[key];
+  }
+  console.error(`Didn't find key ${key} in remoteConfig!`);
+}

--- a/src/store/remoteconfig.ts
+++ b/src/store/remoteconfig.ts
@@ -14,8 +14,12 @@ const DEFAULT_CONFIG: Config = {
 let lastAccessTime: number = 0;
 let config: Config = DEFAULT_CONFIG;
 
+// This entire thing is only needed because Firebase Remote Config isn't
+// supported in Node.js yet, and we don't want to pull the whole web JS SDK
+// in just for this feature.
 export async function getConfig(key: string) {
-  if (Date.now() - lastAccessTime >= REFRESH_MSEC) {
+  const now = Date.now();
+  if (now - lastAccessTime >= REFRESH_MSEC) {
     const snap = await firebase
       .firestore()
       .collection("metadata")
@@ -23,6 +27,7 @@ export async function getConfig(key: string) {
       .get();
 
     if (snap.exists) {
+      lastAccessTime = now;
       config = snap.data() as Config;
     } else {
       console.log(


### PR DESCRIPTION
Remote Config isn't available on React firebase, and so we implement our own super-basic version of it by storing a "metadata/remoteConfig" object in firestore.  We cache reads of that object, and then provide a `getConfig()` function to load that configuration.

I've also changed things so that the Payor tab by default doesn't allow real issuing of payments.  The button label changes, and the payment-issuing functionality is skipped if real payments aren't enabled.

Here's the config object:
![image](https://user-images.githubusercontent.com/42978089/66790722-d742bb00-eea5-11e9-90e3-35afd907f54f.png)

And here's the button label changed based on turning real payments off:
![image](https://user-images.githubusercontent.com/42978089/66790729-e1fd5000-eea5-11e9-8578-49984382613a.png)
