### PR TITLE
Use a more generic TaskPanel to render Payor and Operator tabs

### DIFF
--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -6,7 +6,7 @@ import AdminPanel from "./AdminPanel";
 import AuditorPanel from "./AuditorPanel";
 import MainChrome from "./MainChrome";
 import "./MainView.css";
-import OperatorPanel from "./OperatorPanel";
+import { OperatorItem, OperatorDetails } from "./OperatorPanel";
 import { PayorItem, PayorDetails } from "./PayorPanel";
 import { isCustomPanel, defaultConfig } from "../store/config";
 import TaskPanel from "./TaskPanel";
@@ -20,20 +20,21 @@ const PanelComponents: {
   [key: string]: React.ComponentClass<{}>;
 } = {
   Admin: AdminPanel,
-  AuditTask: AuditorPanel,
-  OperatorTask: OperatorPanel
+  AuditTask: AuditorPanel
 };
 
 const ItemComponents: {
   [key: string]: React.ComponentClass<{ task: Task; isSelected: boolean }>;
 } = {
-  PayorTask: PayorItem
+  PayorTask: PayorItem,
+  OperatorTask: OperatorItem
 };
 
 const DetailsComponents: {
   [key: string]: React.ComponentClass<{ task: Task }>;
 } = {
-  PayorTask: PayorDetails
+  PayorTask: PayorDetails,
+  OperatorTask: OperatorDetails
 };
 
 class MainView extends React.Component<Props, State> {

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -173,7 +173,7 @@ export class PayorItem extends React.Component<{
         <div className="mainview_preview_header">
           <span>{this.props.task.site.name}</span>
         </div>
-        <div>{"Total Reimbursement: " + claimsTotal.toFixed(2) + " KSh"}</div>
+        <div>{"Total Reimbursement: " + formatCurrency(claimsTotal)}</div>
       </div>
     );
   }

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -5,7 +5,6 @@ import DataTable from "../Components/DataTable";
 import LabelTextInput from "../Components/LabelTextInput";
 import LabelWrapper from "../Components/LabelWrapper";
 import NotesAudit from "../Components/NotesAudit";
-import TaskList from "../Components/TaskList";
 import TextItem from "../Components/TextItem";
 import {
   ClaimEntry,
@@ -13,67 +12,39 @@ import {
   formatCurrency,
   getBestUserName,
   issuePayments,
-  loadPayorTasks,
   savePaymentCompletedTask,
   Task
 } from "../store/corestore";
 import { getConfig } from "../store/remoteconfig";
 import "./MainView.css";
 
-type Props = {};
+type Props = {
+  task: Task;
+};
 type State = {
-  tasks: Task[];
   realPayments: boolean;
-  selectedTaskIndex: number;
   notes: string;
   paying: boolean;
 };
 
-class PayorPanel extends React.Component<Props, State> {
-  state: State = {
-    tasks: [],
+export class PayorDetails extends React.Component<Props, State> {
+  state = {
     realPayments: false,
-    selectedTaskIndex: -1,
     notes: "",
     paying: false
   };
 
   async componentDidMount() {
-    const [tasks, realPayments] = await Promise.all([
-      loadPayorTasks(),
-      getConfig("enableRealPayments")
-    ]);
-    this.setState({ tasks, realPayments });
-    if (tasks.length > 0) {
-      this._onTaskSelect(0);
-    }
+    const realPayments = await getConfig("enableRealPayments");
+    this.setState({ realPayments });
   }
-
-  _renderTaskListReimbursement = (task: Task, isSelected: boolean) => {
-    const previewName =
-      "mainview_task_preview" + (isSelected ? " selected" : "");
-    const claimAmounts = task.entries.map(entry => {
-      return entry.claimedCost;
-    });
-    const claimsTotal = claimAmounts.reduce(
-      (sum, claimedCost) => sum + claimedCost
-    );
-    return (
-      <div className={previewName}>
-        <div className="mainview_preview_header">
-          <span>{task.site.name}</span>
-        </div>
-        <div>{"Total Reimbursement: " + formatCurrency(claimsTotal)}</div>
-      </div>
-    );
-  };
 
   _onNotesChanged = (notes: string) => {
     this.setState({ notes });
   };
 
   async _issuePayment(): Promise<boolean> {
-    const task = this.state.tasks[this.state.selectedTaskIndex];
+    const { task } = this.props;
     const reimburseAmount = _getReimbursementTotal(task);
 
     if (reimburseAmount <= 0) {
@@ -116,11 +87,7 @@ class PayorPanel extends React.Component<Props, State> {
         paid = await this._issuePayment();
       }
       if (paid) {
-        await savePaymentCompletedTask(
-          this.state.tasks[this.state.selectedTaskIndex],
-          this.state.notes
-        );
-        this._removeSelectedTask();
+        await savePaymentCompletedTask(this.props.task, this.state.notes);
       }
     } catch (e) {
       alert(`Error: ${(e && e.message) || e}`);
@@ -130,24 +97,13 @@ class PayorPanel extends React.Component<Props, State> {
   };
 
   _onDecline = async () => {
-    const task = this.state.tasks[this.state.selectedTaskIndex];
+    const { task } = this.props;
     await declinePayment(task, this.state.notes);
-    this._removeSelectedTask();
   };
 
-  _removeSelectedTask() {
-    const tasksCopy = this.state.tasks.slice(0);
-
-    tasksCopy.splice(this.state.selectedTaskIndex, 1);
-    const newIndex =
-      this.state.selectedTaskIndex >= tasksCopy.length
-        ? tasksCopy.length - 1
-        : this.state.selectedTaskIndex;
-    this.setState({ tasks: tasksCopy, selectedTaskIndex: newIndex });
-  }
-
-  _renderReimbursementDetails = (task: Task) => {
+  render() {
     const { paying, realPayments } = this.state;
+    const { task } = this.props;
     const claimsTotal = _getReimbursementTotal(task);
     const payLabel = realPayments
       ? paying
@@ -196,29 +152,28 @@ class PayorPanel extends React.Component<Props, State> {
         </div>
       </LabelWrapper>
     );
-  };
+  }
+}
 
-  _onTaskSelect = (index: number) => {
-    this.setState({ selectedTaskIndex: index });
-  };
-
+export class PayorItem extends React.Component<{
+  task: Task;
+  isSelected: boolean;
+}> {
   render() {
-    const { selectedTaskIndex } = this.state;
+    const previewName =
+      "mainview_task_preview" + (this.props.isSelected ? " selected" : "");
+    const claimAmounts = this.props.task.entries.map(entry => {
+      return entry.claimedCost;
+    });
+    const claimsTotal = claimAmounts.reduce(
+      (sum, claimedCost) => sum + claimedCost
+    );
     return (
-      <div className="mainview_content">
-        <TaskList
-          onSelect={this._onTaskSelect}
-          tasks={this.state.tasks}
-          renderItem={this._renderTaskListReimbursement}
-          selectedItem={selectedTaskIndex}
-          className="mainview_tasklist"
-        />
-        <div style={{ width: "100%" }}>
-          {selectedTaskIndex >= 0 &&
-            this._renderReimbursementDetails(
-              this.state.tasks[selectedTaskIndex]
-            )}
+      <div className={previewName}>
+        <div className="mainview_preview_header">
+          <span>{this.props.task.site.name}</span>
         </div>
+        <div>{"Total Reimbursement: " + claimsTotal.toFixed(2) + " KSh"}</div>
       </div>
     );
   }
@@ -230,5 +185,3 @@ function _getReimbursementTotal(task: Task): number {
   });
   return claimAmounts.reduce((sum, claimedCost) => sum + claimedCost);
 }
-
-export default PayorPanel;

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -30,10 +30,7 @@ export default class TaskPanel extends React.Component<Props, State> {
         return;
       }
       if (this.state.selectedTaskIndex === -1) {
-        this.setState({
-          selectedTaskIndex: 0,
-          selectedTaskId: tasks[0].id
-        });
+        this._onTaskSelect(0, tasks);
         return;
       }
       let newIndex = tasks.findIndex(
@@ -42,17 +39,14 @@ export default class TaskPanel extends React.Component<Props, State> {
       if (newIndex === -1) {
         newIndex = Math.min(this.state.selectedTaskIndex, tasks.length - 1);
       }
-      this.setState({
-        selectedTaskIndex: newIndex,
-        selectedTaskId: tasks[newIndex].id
-      });
+      this._onTaskSelect(newIndex, tasks);
     });
   }
 
-  _onTaskSelect = (index: number) => {
+  _onTaskSelect = (index: number, tasks: Task[] = this.state.tasks) => {
     this.setState({
       selectedTaskIndex: index,
-      selectedTaskId: this.state.tasks[index].id
+      selectedTaskId: index === -1 ? undefined : tasks[index].id
     });
   };
 

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import "react-tabs/style/react-tabs.css";
+import TaskList from "../Components/TaskList";
+import { loadTasks, Task } from "../store/corestore";
+import "./MainView.css";
+
+type Props = {
+  taskCollection: string;
+  itemComponent: React.ComponentClass<{ task: Task; isSelected: boolean }>;
+  detailsComponent: React.ComponentClass<{ task: Task }>;
+};
+
+type State = {
+  tasks: Task[];
+  selectedTaskIndex: number;
+};
+
+export default class TaskPanel extends React.Component<Props, State> {
+  state: State = {
+    tasks: [],
+    selectedTaskIndex: -1
+  };
+
+  async componentDidMount() {
+    const tasks = await loadTasks(this.props.taskCollection);
+    this.setState({ tasks });
+    if (tasks.length > 0) {
+      this._onTaskSelect(0);
+    }
+  }
+
+  _onTaskSelect = (index: number) => {
+    this.setState({ selectedTaskIndex: index });
+  };
+
+  _renderTaskListItem = (task: Task, isSelected: boolean) => {
+    return <this.props.itemComponent task={task} isSelected={isSelected} />;
+  };
+
+  render() {
+    const { selectedTaskIndex } = this.state;
+    return (
+      <div className="mainview_content">
+        <TaskList
+          onSelect={this._onTaskSelect}
+          tasks={this.state.tasks}
+          renderItem={this._renderTaskListItem}
+          selectedItem={selectedTaskIndex}
+          className="mainview_tasklist"
+        />
+        <div style={{ width: "100%" }}>
+          {selectedTaskIndex >= 0 && (
+            <this.props.detailsComponent
+              task={this.state.tasks[selectedTaskIndex]}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -23,25 +23,27 @@ export default class TaskPanel extends React.Component<Props, State> {
   };
 
   async componentDidMount() {
-    subscribeToTasks(this.props.taskCollection, tasks => {
-      this.setState({ tasks });
-      if (tasks.length === 0) {
-        this.setState({ selectedTaskIndex: -1, selectedTaskId: undefined });
-        return;
-      }
-      if (this.state.selectedTaskIndex === -1) {
-        this._onTaskSelect(0, tasks);
-        return;
-      }
-      let newIndex = tasks.findIndex(
-        task => task.id === this.state.selectedTaskId
-      );
-      if (newIndex === -1) {
-        newIndex = Math.min(this.state.selectedTaskIndex, tasks.length - 1);
-      }
-      this._onTaskSelect(newIndex, tasks);
-    });
+    subscribeToTasks(this.props.taskCollection, this._onTasksChanged);
   }
+
+  _onTasksChanged = (tasks: Task[]) => {
+    this.setState({ tasks });
+    if (tasks.length === 0) {
+      this.setState({ selectedTaskIndex: -1, selectedTaskId: undefined });
+      return;
+    }
+    if (this.state.selectedTaskIndex === -1) {
+      this._onTaskSelect(0, tasks);
+      return;
+    }
+    let newIndex = tasks.findIndex(
+      task => task.id === this.state.selectedTaskId
+    );
+    if (newIndex === -1) {
+      newIndex = Math.min(this.state.selectedTaskIndex, tasks.length - 1);
+    }
+    this._onTaskSelect(newIndex, tasks);
+  };
 
   _onTaskSelect = (index: number, tasks: Task[] = this.state.tasks) => {
     this.setState({

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -26,17 +26,17 @@ export function isCustomPanel(config: TabConfig): config is CustomPanelConfig {
 
 export const defaultConfig: AppConfig = {
   tabs: {
-    Audit: {
+    Auditor: {
       panelComponent: "AuditTask",
       roles: [UserRole.AUDITOR]
     },
-    Pay: {
+    Payor: {
       taskCollection: "payor_task",
       taskListComponent: "PayorTask",
       detailsComponent: "PayorTask",
       roles: [UserRole.PAYOR]
     },
-    Ops: {
+    Operator: {
       taskCollection: "operator_task",
       taskListComponent: "OperatorTask",
       detailsComponent: "OperatorTask",

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -1,0 +1,48 @@
+import { UserRole } from "./corestore";
+
+interface TabConfig {
+  roles: UserRole[];
+}
+
+interface CustomPanelConfig extends TabConfig {
+  panelComponent: string;
+}
+
+interface TaskConfig extends TabConfig {
+  taskCollection: string;
+  taskListComponent: string;
+  detailsComponent: string;
+}
+
+export interface AppConfig {
+  tabs: {
+    [tab: string]: TaskConfig | CustomPanelConfig;
+  };
+}
+
+export function isCustomPanel(config: TabConfig): config is CustomPanelConfig {
+  return (config as CustomPanelConfig).panelComponent !== undefined;
+}
+
+export const defaultConfig: AppConfig = {
+  tabs: {
+    Audit: {
+      panelComponent: "AuditTask",
+      roles: [UserRole.AUDITOR]
+    },
+    Pay: {
+      taskCollection: "payor_task",
+      taskListComponent: "PayorTask",
+      detailsComponent: "PayorTask",
+      roles: [UserRole.PAYOR]
+    },
+    Ops: {
+      panelComponent: "OperatorTask",
+      roles: [UserRole.OPERATOR]
+    },
+    Admin: {
+      panelComponent: "Admin",
+      roles: [UserRole.ADMIN]
+    }
+  }
+};

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -37,7 +37,9 @@ export const defaultConfig: AppConfig = {
       roles: [UserRole.PAYOR]
     },
     Ops: {
-      panelComponent: "OperatorTask",
+      taskCollection: "operator_task",
+      taskListComponent: "OperatorTask",
+      detailsComponent: "OperatorTask",
       roles: [UserRole.OPERATOR]
     },
     Admin: {

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -278,10 +278,10 @@ export function getBestUserName(): string {
   );
 }
 
-export async function loadPayorTasks(): Promise<Task[]> {
+export async function loadTasks(taskCollection: string): Promise<Task[]> {
   const taskSnapshot = await firebase
     .firestore()
-    .collection(PAYOR_TASK_COLLECTION)
+    .collection(taskCollection)
     .get();
   return taskSnapshot.docs.map(doc => (doc.data() as unknown) as Task);
 }

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -278,12 +278,16 @@ export function getBestUserName(): string {
   );
 }
 
-export async function loadTasks(taskCollection: string): Promise<Task[]> {
-  const taskSnapshot = await firebase
+export function subscribeToTasks(
+  taskCollection: string,
+  callback: (tasks: Task[]) => void
+): () => void {
+  return firebase
     .firestore()
     .collection(taskCollection)
-    .get();
-  return taskSnapshot.docs.map(doc => (doc.data() as unknown) as Task);
+    .onSnapshot(snapshot =>
+      callback(snapshot.docs.map(doc => (doc.data() as unknown) as Task))
+    );
 }
 
 export async function loadOperatorTasks(): Promise<Task[]> {


### PR DESCRIPTION
I'm trying to do two things with this PR:
* Reduce code duplication across tabs
* Move to a more config-driven UI for flows

To those ends, I created a config file under `src/store` that defines the tabs that show up in our app, and a "TaskPanel" component that is meant to render any workflow step based on that config.

For a normal workflow tab, the configuration lists the collection to load tasks from, and the components to use to render the task list item and the details panel. I also plan to make the accept/decline buttons configurable (they mostly do the same thing: save notes and move the task to a different collection), but for now they're still just hardcoded into the respective "details" components.

For non-workflow tabs like the Admin tab, the config can also just accept a component to render the entire tab. I'm also using that for the auditor tab for now, since it has some additional features, but I'll coax that into a set of normal workflow tabs in a followup PR.