### PR TITLE
Make CSV import write Auditor Tasks

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,6 +6,9 @@ service cloud.firestore {
     match /auditor_todo/{docId} {
       allow read, write: if request.auth.token.roles.hasAny(['Auditor'])
     }
+    match /auditor_task/{docId} {
+      allow read, write: if request.auth.token.roles.hasAny(['Auditor'])
+    }
     match /payor_task/{docId} {
       allow write: if request.auth.token.roles.hasAny(['Auditor', 'Operator'])
       allow read, write: if request.auth.token.roles.hasAny(['Payor'])

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -13,3 +13,6 @@ src/africas-talking-options.json
 
 # Firebase deployment auto-gened files
 lib/
+
+# Hacky type-sharing with the main react app
+src/sharedtypes.ts

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
-    "build": "tsc",
+    "build": "cp ../src/sharedtypes.ts src && tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -140,7 +140,7 @@ exports.parseCSV = functions.storage.object().onFinalize(async object => {
     console.log(`Skipping unrecognized file ${filePath}`);
     return;
   }
-  console.log(`Processing ${filePath} of type ${contentType} - new`);
+  console.log(`Processing ${filePath} of type ${contentType}`);
 
   const stream = admin
     .storage()

--- a/src/Components/NotesAudit.tsx
+++ b/src/Components/NotesAudit.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { TaskChangeMetadata } from "../store/corestore";
 import "./NotesAudit.css";
+import { TaskChangeMetadata } from "../sharedtypes";
 
 interface Props {
   change: TaskChangeMetadata;

--- a/src/Components/TaskList.tsx
+++ b/src/Components/TaskList.tsx
@@ -5,10 +5,10 @@ import {
   dateFromServerTimestamp,
   getBestUserName,
   logActiveTaskView,
-  subscribeActiveTasks,
-  Task
+  subscribeActiveTasks
 } from "../store/corestore";
 import "./TaskList.css";
+import { Task } from "../sharedtypes";
 
 const MAX_ACTIVE_MSEC = 5 * 60 * 1000; // 5 mins is considered "active"
 

--- a/src/Components/TopBar.tsx
+++ b/src/Components/TopBar.tsx
@@ -5,8 +5,9 @@ import React, { Fragment } from "react";
 import uploadIcon from "../assets/cloud_upload.svg";
 import logo from "../assets/maishalogo.png";
 import Dropdown from "../Components/Dropdown";
-import { UserRole, userRoles } from "../store/corestore";
+import { userRoles, getBestUserName } from "../store/corestore";
 import "./TopBar.css";
+import { UserRole, UploaderInfo } from "../sharedtypes";
 
 type State = {
   roles: UserRole[];
@@ -53,9 +54,16 @@ class TopBar extends React.Component {
       .ref()
       .child(`csvuploads/${filename}`);
     const file = event.target.files[0];
+    const uploader: UploaderInfo = {
+      uploaderName: getBestUserName(),
+      uploaderID: firebase.auth().currentUser!.uid
+    };
 
     try {
-      await ref.put(file, { contentType: file.type });
+      await ref.put(file, {
+        contentType: file.type,
+        customMetadata: uploader
+      });
 
       alert("File successfully uploaded!");
       this.setState({ showFileSelector: false, selectingFile: false });

--- a/src/Screens/AdminPanel.tsx
+++ b/src/Screens/AdminPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { setRoles, UserRole } from "../store/corestore";
+import { setRoles } from "../store/corestore";
+import { UserRole } from "../sharedtypes";
 
 type RoleMap = {
   [roleName in UserRole]: boolean;

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -15,18 +15,17 @@ import NotesAudit from "../Components/NotesAudit";
 import TaskList from "../Components/TaskList";
 import TextItem from "../Components/TextItem";
 import {
-  ClaimEntry,
   declineAudit,
   formatCurrency,
   loadAuditorTasks,
   loadCompletedPaymentTasks,
   loadRejectedTasks,
-  saveAuditorApprovedTask,
-  Task
+  saveAuditorApprovedTask
 } from "../store/corestore";
 import debounce from "../util/debounce";
 import { containsSearchTerm, DateRange, withinDateRange } from "../util/search";
 import "./MainView.css";
+import { Task, ClaimEntry } from "../sharedtypes";
 
 const MIN_SAMPLE_FRACTION = 0.2;
 const MIN_SAMPLES = 1;

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import "react-tabs/style/react-tabs.css";
-import { UserRole, userRoles, Task } from "../store/corestore";
+import { userRoles } from "../store/corestore";
 import AdminPanel from "./AdminPanel";
 import AuditorPanel from "./AuditorPanel";
 import MainChrome from "./MainChrome";
@@ -10,6 +10,7 @@ import { OperatorItem, OperatorDetails } from "./OperatorPanel";
 import { PayorItem, PayorDetails } from "./PayorPanel";
 import { isCustomPanel, defaultConfig } from "../store/config";
 import TaskPanel from "./TaskPanel";
+import { UserRole, Task } from "../sharedtypes";
 
 type Props = {};
 type State = {

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -7,13 +7,12 @@ import LabelWrapper from "../Components/LabelWrapper";
 import NotesAudit from "../Components/NotesAudit";
 import TextItem from "../Components/TextItem";
 import {
-  ClaimEntry,
   formatCurrency,
   saveOperatorApprovedTask,
-  saveOperatorRejectedTask,
-  Task
+  saveOperatorRejectedTask
 } from "../store/corestore";
 import "./MainView.css";
+import { Task, ClaimEntry } from "../sharedtypes";
 
 type Props = {
   task: Task;

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -7,16 +7,15 @@ import LabelWrapper from "../Components/LabelWrapper";
 import NotesAudit from "../Components/NotesAudit";
 import TextItem from "../Components/TextItem";
 import {
-  ClaimEntry,
   declinePayment,
   formatCurrency,
   getBestUserName,
   issuePayments,
-  savePaymentCompletedTask,
-  Task
+  savePaymentCompletedTask
 } from "../store/corestore";
 import { getConfig } from "../store/remoteconfig";
 import "./MainView.css";
+import { Task, ClaimEntry } from "../sharedtypes";
 
 type Props = {
   task: Task;

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import "react-tabs/style/react-tabs.css";
 import TaskList from "../Components/TaskList";
-import { subscribeToTasks, Task } from "../store/corestore";
+import { subscribeToTasks } from "../store/corestore";
 import "./MainView.css";
+import { Task } from "../sharedtypes";
 
 type Props = {
   taskCollection: string;

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -1,0 +1,99 @@
+/*
+  Until we truly export a private module that allows sharing of common types
+  and functions between the main app and cloud functions, this is the lame way
+  to do it.  This file is copied during `yarn build` in `functions/`.
+
+  You should only put things in here that don't have module dependencies.
+  Simple types, simple functions.
+*/
+export const AUDITOR_TASK_COLLECTION = "auditor_task";
+export const OPERATOR_TASK_COLLECTION = "operator_task";
+export const PAYOR_TASK_COLLECTION = "payor_task";
+export const PAYMENT_COMPLETE_TASK_COLLECTION = "payment_complete_task";
+export const ACTIVE_TASK_COLLECTION = "actively_viewed_tasks";
+export const REJECTED_TASK_COLLECTION = "rejected_task";
+
+export enum UserRole {
+  AUDITOR = "Auditor",
+  PAYOR = "Payor",
+  OPERATOR = "Operator",
+  ADMIN = "Admin"
+}
+
+export enum TaskDecision {
+  DECLINE_AUDIT = "Decline Audit",
+  APPROVE_AUDIT = "Approve Audit",
+  DECLINE_PAYMENT = "Decline Payment",
+  PAYMENT_COMPLETE = "Payment Complete",
+  TASK_REJECTED = "Task Rejected"
+}
+
+export type Site = {
+  name: string;
+  phone?: string;
+};
+
+export type ClaimEntry = {
+  patientAge?: number;
+  patientFirstName: string;
+  patientLastName: string;
+  patientSex?: string;
+  patientID?: string;
+  phone?: string;
+  item: string;
+  totalCost: number;
+  claimedCost: number;
+  photoIDUri?: string;
+  photoMedUri?: string;
+  photoMedBatchUri?: string;
+  timestamp: number;
+  reviewed?: boolean;
+};
+
+export type ClaimTask = {
+  entries: ClaimEntry[];
+  site: Site;
+};
+
+export type TaskChangeMetadata = {
+  timestamp: number;
+  by: string;
+  desc?: string;
+  notes?: string;
+};
+
+export type Task = ClaimTask & {
+  id: string;
+  batchID: string;
+  flow?: TaskDecision;
+  changes: TaskChangeMetadata[];
+};
+
+export type PaymentRecipient = {
+  name?: string;
+  phoneNumber: string;
+  currencyCode: string;
+  amount: number;
+  reason?: string;
+  metadata: {
+    [key: string]: any;
+  };
+};
+
+export type UploaderInfo = {
+  uploaderName: string;
+  uploaderID: string;
+};
+
+// https://stackoverflow.com/questions/286141/remove-blank-attributes-from-an-object-in-javascript
+export function removeEmptyFieldsInPlace(obj: { [key: string]: any }) {
+  Object.keys(obj).forEach(key => {
+    if (obj[key] && typeof obj[key] === "object") {
+      removeEmptyFieldsInPlace(obj[key]);
+      // @ts-ignore
+    } else if (obj[key] == null) {
+      // Note this captures undefined as well!
+      delete obj[key];
+    }
+  });
+}

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -1,4 +1,4 @@
-import { UserRole } from "./corestore";
+import { UserRole } from "../sharedtypes";
 
 interface TabConfig {
   roles: UserRole[];


### PR DESCRIPTION
CSV import used to write blobs into an `auditor_todo` collection which were then translated by the client into Task objects.  We now write task objects directly into an `auditor_task` collection.

This PR looks more complicated than it should be because of the difficulty of sharing common types and JS between the main app and cloud functions.  tsconfig and tslint weren't able to reach into ../src/store/corestore.ts without deployment issues, and so I ultimately decided to do the hacky thing by copying the common types during `yarn build` of `functions/`.  If there's a better way to do this (without creating a private module/etc/etc), please LMK.

The changes:

* Extracted common types into sharedtypes.ts.  This required tweaking a bunch of imports.
* Copy that during `yarn build` into `functions/src` and .gitignore it.
* Change CSV import to write Task objects directly.
* Remove all references to the `auditor_todo` collection, though I left firebase rules alone for now so that we don't break existing clients (until this PR gets in).

Here's the app working again after this:
![image](https://user-images.githubusercontent.com/42978089/67067965-40882f80-f12d-11e9-9ee5-4475bf2cbb1e.png)
