### PR TITLE
FEV-1349: make entire dropdown item box clickable

### DIFF
--- a/src/Components/Dropdown.css
+++ b/src/Components/Dropdown.css
@@ -16,7 +16,7 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  padding: 10px;
+  padding: 0px;
   min-width: 70px;
   min-height: 20px;
   cursor: pointer;

--- a/src/Components/LabelWrapper.css
+++ b/src/Components/LabelWrapper.css
@@ -38,3 +38,14 @@
   display: flex;
   flex-direction: row;
 }
+
+.labelwrapper_dropdown_text {
+  cursor: pointer;
+  color: #000000;
+  text-align: center;
+  font-weight: normal;
+  font-size: medium;
+  width: 100%;
+  height: 100%;
+  padding: 10px;
+}

--- a/src/Components/TopBar.css
+++ b/src/Components/TopBar.css
@@ -33,3 +33,14 @@
   font-weight: bold;
   margin-right: 20px;
 }
+
+.nav_menu_item {
+  cursor: pointer;
+  color: #000000;
+  text-align: center;
+  font-weight: normal;
+  font-size: medium;
+  width: 100%;
+  height: 100%;
+  padding: 10px;
+}

--- a/src/Components/TopBar.tsx
+++ b/src/Components/TopBar.tsx
@@ -96,7 +96,9 @@ class TopBar extends React.Component {
               {uploadButton}
               {uploader}
             </Fragment>
-            <div onClick={this._handleLogout}>Logout</div>
+            <div className="nav_menu_item" onClick={this._handleLogout}>
+              Logout
+            </div>
           </Dropdown>
         </div>
       </div>


### PR DESCRIPTION
At present, a user must click on the text inside the filter/nav menus in order to make a selection. This PR makes the entire box around the item clickable.

![image](https://user-images.githubusercontent.com/29922453/67108544-9edffd00-f183-11e9-836a-2f7cec770ac9.png)
