### PR TITLE
Prevent duplication of CSV uploads

### DIFF
--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -12,6 +12,20 @@ export const PAYOR_TASK_COLLECTION = "payor_task";
 export const PAYMENT_COMPLETE_TASK_COLLECTION = "payment_complete_task";
 export const ACTIVE_TASK_COLLECTION = "actively_viewed_tasks";
 export const REJECTED_TASK_COLLECTION = "rejected_task";
+export const ADMIN_LOG_EVENT_COLLECTION = "admin_log_event";
+export const METADATA_COLLECTION = "metadata";
+
+export const REMOTE_CONFIG_DOC = "remoteConfig";
+
+export type RemoteConfig = {
+  enableRealPayments: boolean;
+  allowDuplicateUploads: boolean;
+};
+
+export const DEFAULT_REMOTE_CONFIG: RemoteConfig = {
+  enableRealPayments: false,
+  allowDuplicateUploads: false
+};
 
 export enum UserRole {
   AUDITOR = "Auditor",
@@ -85,13 +99,24 @@ export type UploaderInfo = {
   uploaderID: string;
 };
 
+export type User = {
+  name: string;
+  id: string;
+};
+
+// This is used to log isuses that the Admin needs to see
+export type AdminLogEvent = {
+  timestamp: number;
+  user: User;
+  desc: string;
+};
+
 // https://stackoverflow.com/questions/286141/remove-blank-attributes-from-an-object-in-javascript
 export function removeEmptyFieldsInPlace(obj: { [key: string]: any }) {
   Object.keys(obj).forEach(key => {
     if (obj[key] && typeof obj[key] === "object") {
       removeEmptyFieldsInPlace(obj[key]);
-      // @ts-ignore
-    } else if (obj[key] == null) {
+    } else if (obj[key] === null || obj[key] === undefined) {
       // Note this captures undefined as well!
       delete obj[key];
     }

--- a/src/store/remoteconfig.ts
+++ b/src/store/remoteconfig.ts
@@ -1,18 +1,16 @@
 import firebase from "firebase/app";
 import "firebase/firestore";
+import {
+  METADATA_COLLECTION,
+  REMOTE_CONFIG_DOC,
+  RemoteConfig,
+  DEFAULT_REMOTE_CONFIG
+} from "../sharedtypes";
 
 const REFRESH_MSEC = 60 * 60 * 1000; // Refresh settings once an hour
 
-type Config = {
-  enableRealPayments: boolean;
-};
-
-const DEFAULT_CONFIG: Config = {
-  enableRealPayments: false
-};
-
 let lastAccessTime: number = 0;
-let config: Config = DEFAULT_CONFIG;
+let config: RemoteConfig = DEFAULT_REMOTE_CONFIG;
 
 // This entire thing is only needed because Firebase Remote Config isn't
 // supported in Node.js yet, and we don't want to pull the whole web JS SDK
@@ -22,13 +20,13 @@ export async function getConfig(key: string) {
   if (now - lastAccessTime >= REFRESH_MSEC) {
     const snap = await firebase
       .firestore()
-      .collection("metadata")
-      .doc("remoteConfig")
+      .collection(METADATA_COLLECTION)
+      .doc(REMOTE_CONFIG_DOC)
       .get();
 
     if (snap.exists) {
       lastAccessTime = now;
-      config = snap.data() as Config;
+      config = snap.data() as RemoteConfig;
     } else {
       console.log(
         "Didn't find /metadata/remoteConfig on server. Using defaults."


### PR DESCRIPTION
Introduces a remote config `allowDuplicateUploads` which defaults to false.  When CSVs are uploaded, the first row is checked against previous uploads, and the upload is rejected if the same ID was found previously.

Because the cloud function runs async from when the user uploads the file, we track this type of rejected duplication in AdminLogEvent objects, which will in a later PR be shown in the Admin panel.

Here's an example of it rejecting a duplicate CSV:
![image](https://user-images.githubusercontent.com/42978089/67133160-79bdaf80-f1c0-11e9-8fb5-d661340cf77f.png)
