### PR TITLE
Denormalize task change metadata

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,6 +3,9 @@ service cloud.firestore {
     match /actively_viewed_tasks/{docId} {
       allow read, write: if true
     }
+    match /task_changes/{docId} {
+      allow read, write: if true
+    }
     match /auditor_todo/{docId} {
       allow read, write: if request.auth.token.roles.hasAny(['Auditor'])
     }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -18,6 +18,10 @@ import {
   User,
   UserRole
 } from "./sharedtypes";
+import {
+  TASK_CHANGE_COLLECTION,
+  TaskChangeRecord
+} from "../../src/sharedtypes.js";
 
 // You're going to need this file on your local machine.  It's stored in our
 // team's LastPass ServerInfrastructure section.
@@ -247,8 +251,20 @@ async function createAuditorTasks(cache: any[], batchID: string, user: User) {
         },
         changes: [change]
       };
+      const record: TaskChangeRecord = {
+        ...change,
+        taskID: doc.id,
+        collection: AUDITOR_TASK_COLLECTION
+      };
       removeEmptyFieldsInPlace(task);
-      await doc.set(task);
+      await Promise.all([
+        doc.set(task),
+        admin
+          .firestore()
+          .collection(TASK_CHANGE_COLLECTION)
+          .doc()
+          .set(record)
+      ]);
     })
   );
   console.log(

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,14 +14,12 @@ import {
   removeEmptyFieldsInPlace,
   Task,
   TaskChangeMetadata,
+  TASK_CHANGE_COLLECTION,
+  TaskChangeRecord,
   UploaderInfo,
   User,
   UserRole
 } from "./sharedtypes";
-import {
-  TASK_CHANGE_COLLECTION,
-  TaskChangeRecord
-} from "../../src/sharedtypes.js";
 
 // You're going to need this file on your local machine.  It's stored in our
 // team's LastPass ServerInfrastructure section.

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -13,6 +13,7 @@ export const PAYMENT_COMPLETE_TASK_COLLECTION = "payment_complete_task";
 export const ACTIVE_TASK_COLLECTION = "actively_viewed_tasks";
 export const REJECTED_TASK_COLLECTION = "rejected_task";
 export const ADMIN_LOG_EVENT_COLLECTION = "admin_log_event";
+export const TASK_CHANGE_COLLECTION = "task_changes";
 export const METADATA_COLLECTION = "metadata";
 
 export const REMOTE_CONFIG_DOC = "remoteConfig";
@@ -74,6 +75,11 @@ export type TaskChangeMetadata = {
   by: string;
   desc?: string;
   notes?: string;
+};
+
+export type TaskChangeRecord = TaskChangeMetadata & {
+  taskID: string;
+  collection: string;
 };
 
 export type Task = ClaimTask & {

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -13,7 +13,10 @@ import {
   PAYMENT_COMPLETE_TASK_COLLECTION,
   PaymentRecipient,
   ACTIVE_TASK_COLLECTION,
-  removeEmptyFieldsInPlace
+  removeEmptyFieldsInPlace,
+  TaskChangeMetadata,
+  TASK_CHANGE_COLLECTION,
+  TaskChangeRecord
 } from "../sharedtypes";
 
 const FIREBASE_CONFIG = {
@@ -73,13 +76,19 @@ async function saveDeclinedTask(
   fromCollection: string,
   notes?: string
 ) {
-  task.flow = decision;
-  task.changes.push({
+  const change: TaskChangeMetadata = {
     timestamp: Date.now(),
     by: getBestUserName(),
     desc: decision as string,
     notes
-  });
+  };
+  const record: TaskChangeRecord = {
+    ...change,
+    taskID: task.id,
+    collection: OPERATOR_TASK_COLLECTION
+  };
+  task.flow = decision;
+  task.changes.push(change);
   removeEmptyFieldsInPlace(task);
 
   return Promise.all([
@@ -88,6 +97,11 @@ async function saveDeclinedTask(
       .collection(OPERATOR_TASK_COLLECTION)
       .doc(task.id)
       .set(task),
+    firebase
+      .firestore()
+      .collection(TASK_CHANGE_COLLECTION)
+      .doc()
+      .set(record),
     firebase
       .firestore()
       .collection(fromCollection)
@@ -101,13 +115,19 @@ export async function saveAuditorApprovedTask(
   notes: string,
   samplesReviewed: number
 ) {
-  task.flow = TaskDecision.APPROVE_AUDIT;
-  task.changes.push({
+  const change: TaskChangeMetadata = {
     timestamp: Date.now(),
     by: getBestUserName(),
     desc: TaskDecision.APPROVE_AUDIT,
     notes
-  });
+  };
+  const record: TaskChangeRecord = {
+    ...change,
+    taskID: task.id,
+    collection: PAYOR_TASK_COLLECTION
+  };
+  task.flow = TaskDecision.APPROVE_AUDIT;
+  task.changes.push(change);
   task.entries = task.entries.map((entry, index) => {
     if (index < samplesReviewed) {
       return {
@@ -127,6 +147,11 @@ export async function saveAuditorApprovedTask(
       .set(task),
     firebase
       .firestore()
+      .collection(TASK_CHANGE_COLLECTION)
+      .doc()
+      .set(record),
+    firebase
+      .firestore()
       .collection(AUDITOR_TASK_COLLECTION)
       .doc(task.id)
       .delete()
@@ -134,13 +159,19 @@ export async function saveAuditorApprovedTask(
 }
 
 export async function saveOperatorApprovedTask(task: Task, notes?: string) {
-  task.flow = TaskDecision.APPROVE_AUDIT;
-  task.changes.push({
+  const change: TaskChangeMetadata = {
     timestamp: Date.now(),
     by: getBestUserName(),
     desc: TaskDecision.APPROVE_AUDIT,
     notes
-  });
+  };
+  const record: TaskChangeRecord = {
+    ...change,
+    taskID: task.id,
+    collection: PAYOR_TASK_COLLECTION
+  };
+  task.flow = TaskDecision.APPROVE_AUDIT;
+  task.changes.push(change);
   removeEmptyFieldsInPlace(task);
 
   return Promise.all([
@@ -151,6 +182,11 @@ export async function saveOperatorApprovedTask(task: Task, notes?: string) {
       .set(task),
     firebase
       .firestore()
+      .collection(TASK_CHANGE_COLLECTION)
+      .doc()
+      .set(record),
+    firebase
+      .firestore()
       .collection(OPERATOR_TASK_COLLECTION)
       .doc(task.id)
       .delete()
@@ -158,13 +194,19 @@ export async function saveOperatorApprovedTask(task: Task, notes?: string) {
 }
 
 export async function saveOperatorRejectedTask(task: Task, notes?: string) {
-  task.flow = TaskDecision.TASK_REJECTED;
-  task.changes.push({
+  const change: TaskChangeMetadata = {
     timestamp: Date.now(),
     by: getBestUserName(),
     desc: TaskDecision.TASK_REJECTED,
     notes
-  });
+  };
+  const record: TaskChangeRecord = {
+    ...change,
+    taskID: task.id,
+    collection: REJECTED_TASK_COLLECTION
+  };
+  task.flow = TaskDecision.TASK_REJECTED;
+  task.changes.push(change);
   removeEmptyFieldsInPlace(task);
 
   return Promise.all([
@@ -175,6 +217,11 @@ export async function saveOperatorRejectedTask(task: Task, notes?: string) {
       .set(task),
     firebase
       .firestore()
+      .collection(TASK_CHANGE_COLLECTION)
+      .doc()
+      .set(record),
+    firebase
+      .firestore()
       .collection(OPERATOR_TASK_COLLECTION)
       .doc(task.id)
       .delete()
@@ -182,13 +229,19 @@ export async function saveOperatorRejectedTask(task: Task, notes?: string) {
 }
 
 export async function savePaymentCompletedTask(task: Task, notes?: string) {
-  task.flow = TaskDecision.PAYMENT_COMPLETE;
-  task.changes.push({
+  const change: TaskChangeMetadata = {
     timestamp: Date.now(),
     by: getBestUserName(),
     desc: TaskDecision.PAYMENT_COMPLETE,
     notes
-  });
+  };
+  const record: TaskChangeRecord = {
+    ...change,
+    taskID: task.id,
+    collection: PAYMENT_COMPLETE_TASK_COLLECTION
+  };
+  task.flow = TaskDecision.PAYMENT_COMPLETE;
+  task.changes.push(change);
   removeEmptyFieldsInPlace(task);
 
   return Promise.all([
@@ -197,6 +250,11 @@ export async function savePaymentCompletedTask(task: Task, notes?: string) {
       .collection(PAYMENT_COMPLETE_TASK_COLLECTION)
       .doc(task.id)
       .set(task),
+    firebase
+      .firestore()
+      .collection(TASK_CHANGE_COLLECTION)
+      .doc()
+      .set(record),
     firebase
       .firestore()
       .collection(PAYOR_TASK_COLLECTION)


### PR DESCRIPTION
Currently, metadata about task changes are held in each task.  But tasks travel between collections.  So showing the admin the latest changes is difficult, because you end up going through all collections filtering by TaskChangeMetadata, sorting by the latest change, etc.

We now write the same metadata, enhanced into TaskChangeRecord, into a top-level collection (`task_changes`).  This denormalizes the data so that we can easily search and filter on all changes, and quickly look up tasks via their change records.

This updates the way we write every TaskChangeMetadata so that the denormalization happens.

Here's an example of a change record in the new collection:
![image](https://user-images.githubusercontent.com/42978089/67134503-59ddba00-f1c7-11e9-8838-19de951fbedf.png)
