### PR TITLE
Entering a Note on One Task Makes It Appear on All 

### DIFF
--- a/src/Components/LabelTextInput.tsx
+++ b/src/Components/LabelTextInput.tsx
@@ -22,7 +22,7 @@ class LabelTextInput extends Component<Props> {
         )}
         <textarea
           className="labeltextinput_input"
-          defaultValue={this.props.defaultValue}
+          value={this.props.defaultValue}
           onChange={this._onTextChange}
         />
       </div>

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -299,7 +299,8 @@ class AuditorPanel extends React.Component<Props, State> {
     this.setState({
       selectedTaskIndex: index,
       numSamples,
-      showAllEntries: false
+      showAllEntries: false,
+      notes: ""
     });
   };
 

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -26,7 +26,7 @@ export class OperatorDetails extends React.Component<Props, State> {
     notes: ""
   };
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentDidUpdate(nextProps: Props) {
     if (nextProps.task !== this.props.task) {
       this.setState({ notes: "" });
     }

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -26,6 +26,12 @@ export class OperatorDetails extends React.Component<Props, State> {
     notes: ""
   };
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (nextProps.task !== this.props.task) {
+      this.setState({ notes: "" });
+    }
+  }
+
   _onNotesChanged = (notes: string) => {
     this.setState({ notes });
   };

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -33,6 +33,12 @@ export class PayorDetails extends React.Component<Props, State> {
     paying: false
   };
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (nextProps.task !== this.props.task) {
+      this.setState({ notes: "" });
+    }
+  }
+
   async componentDidMount() {
     const realPayments = await getConfig("enableRealPayments");
     this.setState({ realPayments });

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -33,7 +33,7 @@ export class PayorDetails extends React.Component<Props, State> {
     paying: false
   };
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentDidUpdate(nextProps: Props) {
     if (nextProps.task !== this.props.task) {
       this.setState({ notes: "" });
     }


### PR DESCRIPTION
[FEV-1338](https://auderenow.atlassian.net/browse/FEV-1338)

* "defaultValue" on textarea doesn't update on prop change, but "value" does
* Updates local notes state when the task has changed