### PR TITLE
Flatten backend data collections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,6 +3,12 @@ service cloud.firestore {
     match /actively_viewed_tasks/{docId} {
       allow read, write: if true
     }
+    match /tasks/{docId} {
+      allow read, write: if request.auth.token.roles.hasAny(['Admin'])
+      allow read, write: if request.auth.token.roles.hasAny(['Auditor']) && (request.resource.data.state == "AUDIT" || resource.data.state == "AUDIT")
+      allow read, write: if request.auth.token.roles.hasAny(['Payor']) && (request.resource.data.state == "PAY" || resource.data.state == "PAY")
+      allow read, write: if request.auth.token.roles.hasAny(['Operator']) && (request.resource.data.state == "FOLLOWUP" || resource.data.state == "FOLLOWUP")
+    }
     match /task_changes/{docId} {
       allow read, write: if true
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
     }
     match /tasks/{docId} {
       allow read, write: if request.auth.token.roles.hasAny(['Admin'])
-      allow read, write: if request.auth.token.roles.hasAny(['Auditor']) && (request.resource.data.state == "AUDIT" || resource.data.state == "AUDIT")
+      allow read, write: if request.auth.token.roles.hasAny(['Auditor']) && (request.resource.data.state == "AUDIT" || resource.data.state == "AUDIT" || request.resource.data.state == "COMPLETED" || resource.data.state == "COMPLETED" || request.resource.data.state == "REJECTED" || resource.data.state == "REJECTED")
       allow read, write: if request.auth.token.roles.hasAny(['Payor']) && (request.resource.data.state == "PAY" || resource.data.state == "PAY")
       allow read, write: if request.auth.token.roles.hasAny(['Operator']) && (request.resource.data.state == "FOLLOWUP" || resource.data.state == "FOLLOWUP")
     }

--- a/src/Components/NotesAudit.tsx
+++ b/src/Components/NotesAudit.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import "./NotesAudit.css";
-import { TaskChangeMetadata } from "../sharedtypes";
+import { TaskChangeRecord } from "../sharedtypes";
 
 interface Props {
-  change: TaskChangeMetadata;
+  change: TaskChangeRecord;
 }
 
 const NotesAudit = (props: Props) => {

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -15,14 +15,12 @@ import LabelWrapper from "../Components/LabelWrapper";
 import NotesAudit from "../Components/NotesAudit";
 import TaskList from "../Components/TaskList";
 import TextItem from "../Components/TextItem";
-import { ClaimEntry, Task } from "../sharedtypes";
+import { ClaimEntry, Task, TaskState, TaskChangeRecord } from "../sharedtypes";
 import {
-  declineAudit,
+  changeTaskState,
   formatCurrency,
-  loadAuditorTasks,
-  loadCompletedPaymentTasks,
-  loadRejectedTasks,
-  saveAuditorApprovedTask
+  loadTasks,
+  getChanges
 } from "../store/corestore";
 import debounce from "../util/debounce";
 import { containsSearchTerm, DateRange, withinDateRange } from "../util/search";
@@ -34,6 +32,7 @@ const MIN_SAMPLES = 1;
 type Props = {};
 type State = {
   tasks: Task[];
+  changes: TaskChangeRecord[][];
   selectedTaskIndex: number;
   allTasks: Task[];
   notes: string;
@@ -55,6 +54,7 @@ enum FilterType {
 class AuditorPanel extends React.Component<Props, State> {
   state: State = {
     tasks: [],
+    changes: [],
     selectedTaskIndex: -1,
     allTasks: [],
     notes: "",
@@ -70,25 +70,27 @@ class AuditorPanel extends React.Component<Props, State> {
   _inputRef: React.RefObject<HTMLInputElement> = React.createRef();
 
   async componentDidMount() {
-    this._setupTaskList();
+    await this._setupTaskList();
   }
 
   _setupTaskList = async () => {
     let tasks;
     switch (this.filterType) {
       case FilterType.TODO:
-        tasks = await loadAuditorTasks();
+        tasks = await loadTasks(TaskState.AUDIT);
         break;
       case FilterType.COMPLETED:
-        tasks = await loadCompletedPaymentTasks();
+        tasks = await loadTasks(TaskState.COMPLETE);
         break;
       case FilterType.REJECTED:
-        tasks = await loadRejectedTasks();
+        tasks = await loadTasks(TaskState.REJECT);
         break;
     }
     if (tasks) {
+      const changes = await Promise.all(tasks.map(t => getChanges(t.id)));
       this.setState({
         tasks,
+        changes,
         allTasks: tasks,
         selectedTaskIndex: -1,
         numSamples: 0
@@ -138,17 +140,24 @@ class AuditorPanel extends React.Component<Props, State> {
   };
 
   _onApprove = async () => {
-    await saveAuditorApprovedTask(
-      this.state.tasks[this.state.selectedTaskIndex],
-      this.state.notes,
-      this.state.numSamples
-    );
+    const task = this.state.tasks[this.state.selectedTaskIndex];
+    task.entries = task.entries.map((entry, index) => {
+      if (index < this.state.numSamples) {
+        return {
+          ...entry,
+          reviewed: true
+        };
+      }
+      return entry;
+    });
+
+    await changeTaskState(task, TaskState.PAY, this.state.notes);
     this._removeSelectedTask();
   };
 
   _onDecline = async () => {
     const task = this.state.tasks[this.state.selectedTaskIndex];
-    await declineAudit(task, this.state.notes);
+    await changeTaskState(task, TaskState.FOLLOWUP, this.state.notes);
     this._removeSelectedTask();
   };
 
@@ -241,7 +250,7 @@ class AuditorPanel extends React.Component<Props, State> {
     this._setSearchTermDetails(input);
   };
 
-  _renderClaimDetails = (task: Task) => {
+  _renderClaimDetails = (task: Task, changes: TaskChangeRecord[]) => {
     const { showAllEntries } = this.state;
     const samples = task.entries.slice(0, this.state.numSamples);
     const remaining = task.entries.length - this.state.numSamples;
@@ -271,7 +280,7 @@ class AuditorPanel extends React.Component<Props, State> {
           task.entries
             .slice(this.state.numSamples, task.entries.length)
             .map(this._renderClaimEntryDetails)}
-        {task.changes.map((change, index) => {
+        {changes.map((change, index) => {
           return <NotesAudit key={change.by + index} change={change} />;
         })}
         {this.filterType === FilterType.TODO && (
@@ -527,7 +536,10 @@ class AuditorPanel extends React.Component<Props, State> {
           />
         </LabelWrapper>
         {selectedTaskIndex >= 0 &&
-          this._renderClaimDetails(this.state.tasks[selectedTaskIndex])}
+          this._renderClaimDetails(
+            this.state.tasks[selectedTaskIndex],
+            this.state.changes[selectedTaskIndex]
+          )}
       </div>
     );
   }

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -80,10 +80,10 @@ class AuditorPanel extends React.Component<Props, State> {
         tasks = await loadTasks(TaskState.AUDIT);
         break;
       case FilterType.COMPLETED:
-        tasks = await loadTasks(TaskState.COMPLETE);
+        tasks = await loadTasks(TaskState.COMPLETED);
         break;
       case FilterType.REJECTED:
-        tasks = await loadTasks(TaskState.REJECT);
+        tasks = await loadTasks(TaskState.REJECTED);
         break;
     }
     if (tasks) {

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -10,7 +10,7 @@ import { OperatorItem, OperatorDetails } from "./OperatorPanel";
 import { PayorItem, PayorDetails } from "./PayorPanel";
 import { isCustomPanel, defaultConfig } from "../store/config";
 import TaskPanel from "./TaskPanel";
-import { UserRole, Task } from "../sharedtypes";
+import { UserRole, Task, TaskChangeRecord } from "../sharedtypes";
 
 type Props = {};
 type State = {
@@ -32,7 +32,10 @@ const ItemComponents: {
 };
 
 const DetailsComponents: {
-  [key: string]: React.ComponentClass<{ task: Task }>;
+  [key: string]: React.ComponentClass<{
+    task: Task;
+    changes: TaskChangeRecord[];
+  }>;
 } = {
   PayorTask: PayorDetails,
   OperatorTask: OperatorDetails
@@ -76,7 +79,7 @@ class MainView extends React.Component<Props, State> {
           } else {
             panelElement = (
               <TaskPanel
-                taskCollection={tabConfig.taskCollection}
+                taskState={tabConfig.taskState}
                 itemComponent={ItemComponents[tabConfig.taskListComponent]}
                 detailsComponent={DetailsComponents[tabConfig.detailsComponent]}
               />

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -34,7 +34,11 @@ export class OperatorDetails extends React.Component<Props, State> {
   };
 
   _onReject = async () => {
-    await changeTaskState(this.props.task, TaskState.REJECT, this.state.notes);
+    await changeTaskState(
+      this.props.task,
+      TaskState.REJECTED,
+      this.state.notes
+    );
   };
 
   _onApprove = async () => {

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -6,16 +6,13 @@ import LabelTextInput from "../Components/LabelTextInput";
 import LabelWrapper from "../Components/LabelWrapper";
 import NotesAudit from "../Components/NotesAudit";
 import TextItem from "../Components/TextItem";
-import { ClaimEntry, Task } from "../sharedtypes";
-import {
-  formatCurrency,
-  saveOperatorApprovedTask,
-  saveOperatorRejectedTask
-} from "../store/corestore";
+import { ClaimEntry, Task, TaskState, TaskChangeRecord } from "../sharedtypes";
+import { formatCurrency, changeTaskState } from "../store/corestore";
 import "./MainView.css";
 
 type Props = {
   task: Task;
+  changes: TaskChangeRecord[];
 };
 type State = {
   notes: string;
@@ -37,11 +34,11 @@ export class OperatorDetails extends React.Component<Props, State> {
   };
 
   _onReject = async () => {
-    await saveOperatorRejectedTask(this.props.task, this.state.notes);
+    await changeTaskState(this.props.task, TaskState.REJECT, this.state.notes);
   };
 
   _onApprove = async () => {
-    await saveOperatorApprovedTask(this.props.task, this.state.notes);
+    await changeTaskState(this.props.task, TaskState.PAY, this.state.notes);
   };
 
   _extractImages = (claim: ClaimEntry) => {
@@ -92,7 +89,7 @@ export class OperatorDetails extends React.Component<Props, State> {
       <LabelWrapper className="mainview_details" label="DETAILS">
         <TextItem data={{ Pharmacy: this.props.task.site.name }} />
         {this.props.task.entries.map(this._renderClaimEntryDetails)}
-        {this.props.task.changes.map((change, index) => {
+        {this.props.changes.map((change, index) => {
           return <NotesAudit key={change.timestamp + index} change={change} />;
         })}
         <LabelTextInput

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -95,7 +95,7 @@ export class PayorDetails extends React.Component<Props, State> {
       if (paid) {
         await changeTaskState(
           this.props.task,
-          TaskState.COMPLETE,
+          TaskState.COMPLETED,
           this.state.notes
         );
       }

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -6,20 +6,21 @@ import LabelTextInput from "../Components/LabelTextInput";
 import LabelWrapper from "../Components/LabelWrapper";
 import NotesAudit from "../Components/NotesAudit";
 import TextItem from "../Components/TextItem";
-import { ClaimEntry, Task } from "../sharedtypes";
+import { ClaimEntry, Task, TaskState, TaskChangeRecord } from "../sharedtypes";
 import {
-  declinePayment,
+  changeTaskState,
   formatCurrency,
   getBestUserName,
-  issuePayments,
-  savePaymentCompletedTask
+  issuePayments
 } from "../store/corestore";
 import { getConfig } from "../store/remoteconfig";
 import "./MainView.css";
 
 type Props = {
   task: Task;
+  changes: TaskChangeRecord[];
 };
+
 type State = {
   realPayments: boolean;
   notes: string;
@@ -92,7 +93,11 @@ export class PayorDetails extends React.Component<Props, State> {
         paid = await this._issuePayment();
       }
       if (paid) {
-        await savePaymentCompletedTask(this.props.task, this.state.notes);
+        await changeTaskState(
+          this.props.task,
+          TaskState.COMPLETE,
+          this.state.notes
+        );
       }
     } catch (e) {
       alert(`Error: ${(e && e.message) || e}`);
@@ -103,7 +108,7 @@ export class PayorDetails extends React.Component<Props, State> {
 
   _onDecline = async () => {
     const { task } = this.props;
-    await declinePayment(task, this.state.notes);
+    await changeTaskState(task, TaskState.FOLLOWUP, this.state.notes);
   };
 
   render() {
@@ -137,7 +142,7 @@ export class PayorDetails extends React.Component<Props, State> {
           }}
         />
         <DataTable data={cleanedData} />
-        {task.changes.map((change, index) => {
+        {this.props.changes.map((change, index) => {
           return <NotesAudit key={change.timestamp + index} change={change} />;
         })}
         <LabelTextInput

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -43,28 +43,34 @@ export default class TaskPanel extends React.Component<Props, State> {
 
   _onTasksChanged = async (tasks: Task[]) => {
     const changes = await Promise.all(tasks.map(t => getChanges(t.id)));
-    this.setState({ tasks, changes });
+    let { selectedTaskIndex, selectedTaskId } = this.state;
+
     if (tasks.length === 0) {
-      this.setState({ selectedTaskIndex: -1, selectedTaskId: undefined });
-      return;
+      selectedTaskIndex = -1;
+      selectedTaskId = undefined;
+    } else {
+      if (selectedTaskIndex === -1) {
+        selectedTaskIndex = 0;
+        selectedTaskId = tasks[0].id;
+      } else {
+        selectedTaskIndex = tasks.findIndex(task => task.id === selectedTaskId);
+        if (selectedTaskIndex === -1) {
+          selectedTaskIndex = Math.min(
+            this.state.selectedTaskIndex,
+            tasks.length - 1
+          );
+          selectedTaskId = tasks[selectedTaskIndex].id;
+        }
+      }
     }
-    if (this.state.selectedTaskIndex === -1) {
-      this._onTaskSelect(0, tasks);
-      return;
-    }
-    let newIndex = tasks.findIndex(
-      task => task.id === this.state.selectedTaskId
-    );
-    if (newIndex === -1) {
-      newIndex = Math.min(this.state.selectedTaskIndex, tasks.length - 1);
-    }
-    this._onTaskSelect(newIndex, tasks);
+
+    this.setState({ tasks, changes, selectedTaskIndex, selectedTaskId });
   };
 
-  _onTaskSelect = (index: number, tasks: Task[] = this.state.tasks) => {
+  _onTaskSelect = (index: number) => {
     this.setState({
       selectedTaskIndex: index,
-      selectedTaskId: index === -1 ? undefined : tasks[index].id
+      selectedTaskId: index === -1 ? undefined : this.state.tasks[index].id
     });
   };
 

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -17,8 +17,8 @@ export enum TaskState {
   AUDIT = "AUDIT",
   FOLLOWUP = "FOLLOWUP",
   PAY = "PAY",
-  COMPLETE = "COMPLETE",
-  REJECT = "REJECT"
+  COMPLETED = "COMPLETED",
+  REJECTED = "REJECTED"
 }
 
 export const REMOTE_CONFIG_DOC = "remoteConfig";

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -16,6 +16,16 @@ export const ADMIN_LOG_EVENT_COLLECTION = "admin_log_event";
 export const TASK_CHANGE_COLLECTION = "task_changes";
 export const METADATA_COLLECTION = "metadata";
 
+export const TASKS_COLLECTION = "tasks";
+export enum TaskState {
+  CSV = "CSV",
+  AUDIT = "AUDIT",
+  FOLLOWUP = "FOLLOWUP",
+  PAY = "PAY",
+  COMPLETE = "COMPLETE",
+  REJECT = "REJECT"
+}
+
 export const REMOTE_CONFIG_DOC = "remoteConfig";
 
 export type RemoteConfig = {
@@ -33,14 +43,6 @@ export enum UserRole {
   PAYOR = "Payor",
   OPERATOR = "Operator",
   ADMIN = "Admin"
-}
-
-export enum TaskDecision {
-  DECLINE_AUDIT = "Decline Audit",
-  APPROVE_AUDIT = "Approve Audit",
-  DECLINE_PAYMENT = "Decline Payment",
-  PAYMENT_COMPLETE = "Payment Complete",
-  TASK_REJECTED = "Task Rejected"
 }
 
 export type Site = {
@@ -65,28 +67,22 @@ export type ClaimEntry = {
   reviewed?: boolean;
 };
 
-export type ClaimTask = {
-  entries: ClaimEntry[];
-  site: Site;
-};
-
-export type TaskChangeMetadata = {
+export type TaskChangeRecord = {
+  taskID: string;
+  state: TaskState;
+  fromState: TaskState;
   timestamp: number;
   by: string;
-  desc?: string;
+  desc: string;
   notes?: string;
 };
 
-export type TaskChangeRecord = TaskChangeMetadata & {
-  taskID: string;
-  collection: string;
-};
-
-export type Task = ClaimTask & {
+export type Task = {
   id: string;
   batchID: string;
-  flow?: TaskDecision;
-  changes: TaskChangeMetadata[];
+  state: TaskState;
+  entries: ClaimEntry[];
+  site: Site;
 };
 
 export type PaymentRecipient = {

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -6,17 +6,12 @@
   You should only put things in here that don't have module dependencies.
   Simple types, simple functions.
 */
-export const AUDITOR_TASK_COLLECTION = "auditor_task";
-export const OPERATOR_TASK_COLLECTION = "operator_task";
-export const PAYOR_TASK_COLLECTION = "payor_task";
-export const PAYMENT_COMPLETE_TASK_COLLECTION = "payment_complete_task";
 export const ACTIVE_TASK_COLLECTION = "actively_viewed_tasks";
-export const REJECTED_TASK_COLLECTION = "rejected_task";
 export const ADMIN_LOG_EVENT_COLLECTION = "admin_log_event";
 export const TASK_CHANGE_COLLECTION = "task_changes";
 export const METADATA_COLLECTION = "metadata";
-
 export const TASKS_COLLECTION = "tasks";
+
 export enum TaskState {
   CSV = "CSV",
   AUDIT = "AUDIT",

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -1,4 +1,4 @@
-import { UserRole } from "../sharedtypes";
+import { UserRole, TaskState } from "../sharedtypes";
 
 interface TabConfig {
   roles: UserRole[];
@@ -9,7 +9,7 @@ interface CustomPanelConfig extends TabConfig {
 }
 
 interface TaskConfig extends TabConfig {
-  taskCollection: string;
+  taskState: TaskState;
   taskListComponent: string;
   detailsComponent: string;
 }
@@ -31,13 +31,13 @@ export const defaultConfig: AppConfig = {
       roles: [UserRole.AUDITOR]
     },
     Payor: {
-      taskCollection: "payor_task",
+      taskState: TaskState.PAY,
       taskListComponent: "PayorTask",
       detailsComponent: "PayorTask",
       roles: [UserRole.PAYOR]
     },
     Operator: {
-      taskCollection: "operator_task",
+      taskState: TaskState.FOLLOWUP,
       taskListComponent: "OperatorTask",
       detailsComponent: "OperatorTask",
       roles: [UserRole.OPERATOR]


### PR DESCRIPTION
This implements what we talked about last week, where all tasks now reside in the `tasks` collection, changing state instead of being copied back & forth between different collections.

* Code greatly simplified in corestore, now that it can handle tasks generically.
* Auditor's `entries` editing moved out into the AuditorPanel to maintain corestore genericness
* TaskChangeRecord now not replicated in Task.  This simplifies and normalizes the data model, but required that panels load these change records themselves instead of counting on the replica within each Task.
* CSV upload modified to conform to new data model
* Firebase rules updated to protect reads/writes in the correct way
* Renamed the "operator" state into `FOLLOWUP`,  which I think better reflects what that state actually is.

This change results in no functionality difference -- it changes only the way we store data.  Once this lands, I'll do a separate diff to remove collections no longer used.

Here's how the new `tasks` collection looks after CSV upload:
![image](https://user-images.githubusercontent.com/42978089/67316304-0a480880-f4bd-11e9-8aa4-d883341d847a.png)
