### PR TITLE
Deduplicate uploaded records

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -236,7 +236,6 @@ async function createAuditorTasks(cache: any[], batchID: string, user: User) {
         .collection(TASKS_COLLECTION)
         .doc();
       const patients = pharm.values.map((d: any) => ({
-        csvID: d[RECORD_ID_FIELD],
         patientAge: d["g2:A12 Age"],
         patientFirstName: d["g2:A10 First Name"],
         patientLastName: d["g2:A11 Last Name"],

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -74,7 +74,6 @@ export type TaskChangeRecord = {
 
 export type Task = {
   id: string;
-  batchID: string;
   state: TaskState;
   entries: ClaimEntry[];
   site: Site;


### PR DESCRIPTION
This implements full deduplication of CSV uploads on a row-by-row basis by using meta:instanceID from ODK as the unique identifier of records.

* We simplify and flatten the "uploaded records" structure so that one row for each record ever uploaded is stored in the `uploaded_records` collection.
* We scan that collection for newly uploaded meta:instanceIDs, and avoid reinserting IDs we've seen in the past.
* We regenerate a single admin log for each case where a CSV repeats a previously-seen ID.

Note that the "did I previously upload this" search is linear, leading to an O(n^2) implementation of de-duping when it comes to firestore searches.  This is because firestore does not support the concept of querying for records where any of a set of IDs are looked for.  An alternative, faster implementation would be to store all record IDs in one array, since Firestore has an `array-contains` query capability;  however, firestore arrays are limited to a certain modest size, so we wouldn't want to hit that limit.

Here's what the admin record looks like when you have dupes:
![image](https://user-images.githubusercontent.com/42978089/67325431-053d8600-f4ca-11e9-9e12-5e775a308acd.png)

Here's proof that we only insert non-dupe IDs.  I uploaded the same CSV, but only changed two records (into store 24 and 25).  The other records aren't reinserted, and the admin record shows the other records as rejected.
![image](https://user-images.githubusercontent.com/42978089/67325521-2900cc00-f4ca-11e9-929c-92cc560e6716.png)
