### PR TITLE
Impvroved notes

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -213,8 +213,7 @@ async function createAuditorTasks(cache: any[], batchID: string, user: User) {
   }));
   const changeTemplate = {
     timestamp: Date.now(),
-    by: user.name,
-    desc: `Uploaded CSV containing ${shuffledRowsByPharmacy.length} pharmacies`
+    by: user.name
   };
 
   // Now generate Auditor work items representing each sampled row.

--- a/src/Components/NotesAudit.tsx
+++ b/src/Components/NotesAudit.tsx
@@ -7,18 +7,21 @@ interface Props {
 }
 
 const NotesAudit = (props: Props) => {
-  if (!props.change.notes) {
-    return null;
-  }
-
-  const { timestamp, by, notes } = props.change;
+  const { timestamp, by, state, fromState, notes } = props.change;
+  const notesClause = notes ? (
+    <span>
+      {": "}
+      <strong>{notes}</strong>
+    </span>
+  ) : (
+    ""
+  );
+  const desc = `moved from ${fromState} to ${state}`;
   return (
     <div className="notesaudit_row" key={`${props.change.timestamp}`}>
-      <b>
-        {`${by} on
-            ${new Date(timestamp).toLocaleString()}: `}
-      </b>
-      {notes}
+      {`${by} ${desc} on
+            ${new Date(timestamp).toLocaleString()}`}
+      {notesClause}
     </div>
   );
 };

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -280,6 +280,7 @@ class AuditorPanel extends React.Component<Props, State> {
           task.entries
             .slice(this.state.numSamples, task.entries.length)
             .map(this._renderClaimEntryDetails)}
+        <div className="mainview_actions_so_far_header">Actions so far:</div>
         {changes.map((change, index) => {
           return <NotesAudit key={change.by + index} change={change} />;
         })}

--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -71,3 +71,9 @@
   flex-direction: column;
   flex: 4;
 }
+
+.mainview_actions_so_far_header {
+  margin-top: 12px;
+  margin: 5px;
+  font-weight: bold;
+}

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -93,6 +93,7 @@ export class OperatorDetails extends React.Component<Props, State> {
       <LabelWrapper className="mainview_details" label="DETAILS">
         <TextItem data={{ Pharmacy: this.props.task.site.name }} />
         {this.props.task.entries.map(this._renderClaimEntryDetails)}
+        <div className="mainview_actions_so_far_header">Actions so far:</div>
         {this.props.changes.map((change, index) => {
           return <NotesAudit key={change.timestamp + index} change={change} />;
         })}

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -142,6 +142,7 @@ export class PayorDetails extends React.Component<Props, State> {
           }}
         />
         <DataTable data={cleanedData} />
+        <div className="mainview_actions_so_far_header">Actions so far:</div>
         {this.props.changes.map((change, index) => {
           return <NotesAudit key={change.timestamp + index} change={change} />;
         })}

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -68,7 +68,6 @@ export type TaskChangeRecord = {
   fromState: TaskState;
   timestamp: number;
   by: string;
-  desc: string;
   notes?: string;
 };
 

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -58,7 +58,6 @@ export async function changeTaskState(
     fromState: task.state,
     timestamp: Date.now(),
     by: getBestUserName(),
-    desc: `Changed to ${newState}`,
     notes
   };
   const updatedTask = {
@@ -107,6 +106,7 @@ export async function getChanges(taskID: string) {
     .firestore()
     .collection(TASK_CHANGE_COLLECTION)
     .where("taskID", "==", taskID)
+    .orderBy("timestamp")
     .get();
   return changes.docs.map(d => d.data() as TaskChangeRecord);
 }


### PR DESCRIPTION
This updates how we show notes.

1. We now show all state transitions (instead of just the ones with notes)
2. We label the audit notes area with a header
3. We auto-generate the change description instead of requiring a `desc` in every change
4. We bold the note itself instead of the change.  Looks much better, IMO.
5. We order the changelog by time.  We didn't do that before (!).

![image](https://user-images.githubusercontent.com/42978089/67328897-fa392480-f4ce-11e9-8398-a742f1715bc3.png)
