### PR TITLE
TaskList Expands to Fill Screen When No Results Are Given

### DIFF
--- a/src/Components/DateRangePickerOverride.css
+++ b/src/Components/DateRangePickerOverride.css
@@ -1,3 +1,12 @@
 .DateRangePickerInput {
   overflow: hidden;
 }
+
+.DateRangePicker {
+  position: static;
+}
+
+.DateRangePicker_picker {
+  left: 30px !important;
+  top: 185px !important;
+}

--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -12,7 +12,7 @@
 }
 
 .mainview_tasklist {
-  width: 15%;
+  width: 20%;
   display: flex;
   flex-direction: column;
 }

--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -13,9 +13,9 @@
 
 .mainview_tasklist {
   min-width: 300px;
+  max-width: 25%;
   display: flex;
   flex-direction: column;
-  flex: 1;
 }
 
 .mainview_task_preview {

--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -12,8 +12,7 @@
 }
 
 .mainview_tasklist {
-  min-width: 300px;
-  max-width: 25%;
+  width: 15%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
[FEV-54](https://github.com/AudereNow/flows/pull/54)

Overrode some styling with exact pixel values: a bad move, but since the container is "display: relative" and the calendar is "display:absolute" there is nothing we can do in terms of z-index and having the calendar as part of the flow would push all of the search bars, download CSV button, etc down.

![No Results Date Picker](https://user-images.githubusercontent.com/15152013/67339994-2f4e7280-f4e1-11e9-9bf0-aee2400517cc.png)
