### PR TITLE
Make CSV upload and processing synchronous

### DIFF
--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -147,6 +147,14 @@ export async function issuePayments(recipients: PaymentRecipient[]) {
   });
 }
 
+export async function uploadCSV(content: any) {
+  const serverUploadCSV = firebase.functions().httpsCallable("uploadCSV");
+
+  return await serverUploadCSV({
+    content
+  });
+}
+
 export function toServerTimestamp(date: Date): firebase.firestore.Timestamp {
   return firebase.firestore.Timestamp.fromDate(date);
 }


### PR DESCRIPTION
Now that we have UI to upload files, we make CSV processing synchronous so that we can show the uploading user any errors that happen when processing their upload.

* We no longer use Firebase Storage to store CSVs.  We just process them as strings.
* We've removed the Storage hook `parseCSV`, and are instead now using `uploadCSV`
* We show the user any errors.  Upon success, we tell them how many records were processed.

A future PR will address waiting UI so that the user knows something is happening.  And auto-dismissing the menu.