### PR TITLE
Convert Auditor Tab to use TaskPanel

### DIFF
--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -13,7 +13,6 @@ import ImageRow from "../Components/ImageRow";
 import LabelTextInput from "../Components/LabelTextInput";
 import LabelWrapper from "../Components/LabelWrapper";
 import NotesAudit from "../Components/NotesAudit";
-import TaskList from "../Components/TaskList";
 import TextItem from "../Components/TextItem";
 import { ClaimEntry, Task, TaskState, TaskChangeRecord } from "../sharedtypes";
 import {
@@ -32,6 +31,7 @@ const MIN_SAMPLES = 1;
 type Props = {
   task: Task;
   changes: TaskChangeRecord[];
+  actionable?: boolean;
 };
 type State = {
   tasks: Task[];
@@ -264,6 +264,8 @@ export class AuditorDetails extends React.Component<Props, State> {
     const { task, changes } = this.props;
     const samples = task.entries.slice(0, this.state.numSamples);
     const remaining = task.entries.length - this.state.numSamples;
+    const actionable =
+      this.props.actionable !== undefined ? this.props.actionable : true;
     return (
       <LabelWrapper className="mainview_details" label="DETAILS">
         <div className="mainview_spaced_row">
@@ -294,14 +296,14 @@ export class AuditorDetails extends React.Component<Props, State> {
         {changes.map((change, index) => {
           return <NotesAudit key={change.by + index} change={change} />;
         })}
-        {this.filterType === FilterType.TODO && (
+        {actionable && (
           <LabelTextInput
             onTextChange={this._onNotesChanged}
             label={"Notes"}
             value={this.state.notes}
           />
         )}
-        {this.filterType === FilterType.TODO && (
+        {actionable && (
           <div className="mainview_button_row">
             <Button label="Decline" onClick={this._onDecline} />
             <Button label="Approve" onClick={this._onApprove} />

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -29,7 +29,10 @@ import "./MainView.css";
 const MIN_SAMPLE_FRACTION = 0.2;
 const MIN_SAMPLES = 1;
 
-type Props = {};
+type Props = {
+  task: Task;
+  changes: TaskChangeRecord[];
+};
 type State = {
   tasks: Task[];
   changes: TaskChangeRecord[][];
@@ -51,7 +54,33 @@ enum FilterType {
   REJECTED = "Rejected"
 }
 
-class AuditorPanel extends React.Component<Props, State> {
+export class AuditorItem extends React.Component<{
+  task: Task;
+  isSelected: boolean;
+}> {
+  render() {
+    const { task, isSelected } = this.props;
+    const previewName =
+      "mainview_task_preview" + (isSelected ? " selected" : "");
+    const claimAmounts = task.entries.map(entry => {
+      return entry.claimedCost;
+    });
+    const claimsTotal = claimAmounts.reduce(
+      (sum, claimedCost) => sum + claimedCost
+    );
+    return (
+      <div className={previewName}>
+        <div className="mainview_preview_header">
+          <span>{task.site.name}</span>
+          <span>{task.entries.length} Claims</span>
+        </div>
+        <div>{"Total Reimbursement: " + formatCurrency(claimsTotal)}</div>
+      </div>
+    );
+  }
+}
+
+export class AuditorDetails extends React.Component<Props, State> {
   state: State = {
     tasks: [],
     changes: [],
@@ -109,26 +138,6 @@ class AuditorPanel extends React.Component<Props, State> {
         return "REJECTED CLAIMS";
     }
     return "ITEMS TO REVIEW";
-  };
-
-  _renderTaskListClaim = (task: Task, isSelected: boolean) => {
-    const previewName =
-      "mainview_task_preview" + (isSelected ? " selected" : "");
-    const claimAmounts = task.entries.map(entry => {
-      return entry.claimedCost;
-    });
-    const claimsTotal = claimAmounts.reduce(
-      (sum, claimedCost) => sum + claimedCost
-    );
-    return (
-      <div className={previewName}>
-        <div className="mainview_preview_header">
-          <span>{task.site.name}</span>
-          <span>{task.entries.length} Claims</span>
-        </div>
-        <div>{"Total Reimbursement: " + formatCurrency(claimsTotal)}</div>
-      </div>
-    );
   };
 
   _onShowAll = () => {
@@ -250,8 +259,9 @@ class AuditorPanel extends React.Component<Props, State> {
     this._setSearchTermDetails(input);
   };
 
-  _renderClaimDetails = (task: Task, changes: TaskChangeRecord[]) => {
+  render() {
     const { showAllEntries } = this.state;
+    const { task, changes } = this.props;
     const samples = task.entries.slice(0, this.state.numSamples);
     const remaining = task.entries.length - this.state.numSamples;
     return (
@@ -299,7 +309,7 @@ class AuditorPanel extends React.Component<Props, State> {
         )}
       </LabelWrapper>
     );
-  };
+  }
 
   _onTaskSelect = (index: number) => {
     const numSamples = Math.max(
@@ -518,34 +528,4 @@ class AuditorPanel extends React.Component<Props, State> {
       </div>
     );
   };
-
-  render() {
-    const { selectedTaskIndex, showSearch } = this.state;
-    return (
-      <div className="mainview_content">
-        <LabelWrapper
-          label={`${this._getLabelFromFilterType()}: ${
-            this.state.tasks.length
-          }`}
-          className="mainview_tasklist"
-          renderLabelItems={this._renderLabelItems}
-        >
-          {!!showSearch && <div>{this._renderSearchPanel()}</div>}
-          <TaskList
-            onSelect={this._onTaskSelect}
-            tasks={this.state.tasks}
-            renderItem={this._renderTaskListClaim}
-            selectedItem={selectedTaskIndex}
-          />
-        </LabelWrapper>
-        {selectedTaskIndex >= 0 &&
-          this._renderClaimDetails(
-            this.state.tasks[selectedTaskIndex],
-            this.state.changes[selectedTaskIndex]
-          )}
-      </div>
-    );
-  }
 }
-
-export default AuditorPanel;

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -35,6 +35,7 @@ const DetailsComponents: {
   [key: string]: React.ComponentClass<{
     task: Task;
     changes: TaskChangeRecord[];
+    actionable?: boolean;
   }>;
 } = {
   AuditTask: AuditorDetails,
@@ -84,6 +85,7 @@ class MainView extends React.Component<Props, State> {
                 itemComponent={ItemComponents[tabConfig.taskListComponent]}
                 detailsComponent={DetailsComponents[tabConfig.detailsComponent]}
                 listLabel={tabConfig.listLabel}
+                actionable={tabConfig.actionable}
               />
             );
           }

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -3,9 +3,9 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import "react-tabs/style/react-tabs.css";
 import { userRoles } from "../store/corestore";
 import AdminPanel from "./AdminPanel";
-import AuditorPanel from "./AuditorPanel";
 import MainChrome from "./MainChrome";
 import "./MainView.css";
+import { AuditorItem, AuditorDetails } from "./AuditorPanel";
 import { OperatorItem, OperatorDetails } from "./OperatorPanel";
 import { PayorItem, PayorDetails } from "./PayorPanel";
 import { isCustomPanel, defaultConfig } from "../store/config";
@@ -20,13 +20,13 @@ type State = {
 const PanelComponents: {
   [key: string]: React.ComponentClass<{}>;
 } = {
-  Admin: AdminPanel,
-  AuditTask: AuditorPanel
+  Admin: AdminPanel
 };
 
 const ItemComponents: {
   [key: string]: React.ComponentClass<{ task: Task; isSelected: boolean }>;
 } = {
+  AuditTask: AuditorItem,
   PayorTask: PayorItem,
   OperatorTask: OperatorItem
 };
@@ -37,6 +37,7 @@ const DetailsComponents: {
     changes: TaskChangeRecord[];
   }>;
 } = {
+  AuditTask: AuditorDetails,
   PayorTask: PayorDetails,
   OperatorTask: OperatorDetails
 };
@@ -82,6 +83,7 @@ class MainView extends React.Component<Props, State> {
                 taskState={tabConfig.taskState}
                 itemComponent={ItemComponents[tabConfig.taskListComponent]}
                 detailsComponent={DetailsComponents[tabConfig.detailsComponent]}
+                listLabel={tabConfig.listLabel}
               />
             );
           }

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -19,7 +19,9 @@ type Props = {
   detailsComponent: React.ComponentClass<{
     task: Task;
     changes: TaskChangeRecord[];
+    actionable?: boolean;
   }>;
+  actionable?: boolean;
 };
 
 type State = {
@@ -296,6 +298,7 @@ export default class TaskPanel extends React.Component<Props, State> {
             <this.props.detailsComponent
               task={this.state.tasks[selectedTaskIndex]}
               changes={this.state.changes[selectedTaskIndex]}
+              actionable={this.props.actionable}
             />
           )}
         </div>

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -1,13 +1,20 @@
-import React from "react";
+import { json2csv } from "json-2-csv";
+import { Moment } from "moment";
+import React, { Fragment } from "react";
+import { DateRangePicker, FocusedInputShape } from "react-dates";
 import "react-tabs/style/react-tabs.css";
+import Button from "../Components/Button";
 import LabelWrapper from "../Components/LabelWrapper";
 import TaskList from "../Components/TaskList";
 import { Task, TaskState, TaskChangeRecord } from "../sharedtypes";
 import { subscribeToTasks, getChanges } from "../store/corestore";
+import debounce from "../util/debounce";
+import { containsSearchTerm, DateRange, withinDateRange } from "../util/search";
 import "./MainView.css";
 
 type Props = {
   taskState: TaskState;
+  listLabel: string;
   itemComponent: React.ComponentClass<{ task: Task; isSelected: boolean }>;
   detailsComponent: React.ComponentClass<{
     task: Task;
@@ -16,19 +23,30 @@ type Props = {
 };
 
 type State = {
+  allTasks: Task[];
   tasks: Task[];
   changes: TaskChangeRecord[][];
   selectedTaskIndex: number;
   selectedTaskId?: string;
+  focusedInput: FocusedInputShape | null;
+  searchDates: DateRange;
+  searchTermGlobal: string;
+  showSearch: boolean;
 };
 
 export default class TaskPanel extends React.Component<Props, State> {
   state: State = {
+    allTasks: [],
     tasks: [],
     changes: [],
-    selectedTaskIndex: -1
+    selectedTaskIndex: -1,
+    focusedInput: null,
+    searchDates: { startDate: null, endDate: null },
+    searchTermGlobal: "",
+    showSearch: false
   };
   _unsubscribe = () => {};
+  _inputRef: React.RefObject<HTMLInputElement> = React.createRef();
 
   async componentDidMount() {
     this._unsubscribe = subscribeToTasks(
@@ -64,7 +82,13 @@ export default class TaskPanel extends React.Component<Props, State> {
       }
     }
 
-    this.setState({ tasks, changes, selectedTaskIndex, selectedTaskId });
+    this.setState({
+      allTasks: tasks,
+      tasks,
+      changes,
+      selectedTaskIndex,
+      selectedTaskId
+    });
   };
 
   _onTaskSelect = (index: number) => {
@@ -78,14 +102,187 @@ export default class TaskPanel extends React.Component<Props, State> {
     return <this.props.itemComponent task={task} isSelected={isSelected} />;
   };
 
+  _onSearchClick = () => {
+    this.setState({ showSearch: !this.state.showSearch });
+  };
+
+  _renderLabelItems = () => {
+    return (
+      <Fragment>
+        <div className="labelwrapper_header_icon" onClick={this._onSearchClick}>
+          &nbsp;&#x1F50E;
+        </div>
+      </Fragment>
+    );
+  };
+
+  _onFocusChange = (focusedInput: FocusedInputShape | null) => {
+    this.setState({ focusedInput });
+  };
+
+  _onDatesChange = ({
+    startDate,
+    endDate
+  }: {
+    startDate: Moment | null;
+    endDate: Moment | null;
+  }) => {
+    this._handleSearchDatesChange({ startDate, endDate });
+  };
+
+  _onSearchTermChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    let input = event.target.value;
+    this._handleSearchTermGlobalChange(input);
+  };
+
+  _computeFilteredTasks = (searchTerm: string, dateRange: DateRange) => {
+    return this.state.allTasks.filter(task => {
+      return (
+        (containsSearchTerm(searchTerm, task.site) ||
+          task.entries.some(entry => {
+            return containsSearchTerm(searchTerm, entry);
+          })) &&
+        task.entries.some(entry => {
+          return withinDateRange(dateRange, entry);
+        })
+      );
+    });
+  };
+
+  _handleSearchTermGlobalChange = debounce((searchTerm: string) => {
+    const { selectedTaskIndex, tasks } = this.state;
+    const selectedId =
+      selectedTaskIndex >= 0 ? tasks[selectedTaskIndex].id : "";
+    const filteredTasks = this._computeFilteredTasks(
+      searchTerm,
+      this.state.searchDates
+    );
+    const selectedIndex = filteredTasks.findIndex(task => {
+      return task.id === selectedId;
+    });
+    this.setState(
+      {
+        tasks: filteredTasks,
+        searchTermGlobal: searchTerm,
+        selectedTaskIndex: selectedIndex
+      },
+      () => {
+        if (selectedIndex === -1 && filteredTasks.length > 0) {
+          this._onTaskSelect(0);
+        }
+      }
+    );
+  }, 500);
+
+  _handleSearchDatesChange = (searchDates: DateRange) => {
+    const { selectedTaskIndex, tasks } = this.state;
+    const selectedId =
+      selectedTaskIndex >= 0 ? tasks[selectedTaskIndex].id : "";
+    const filteredTasks = this._computeFilteredTasks(
+      this.state.searchTermGlobal,
+      searchDates
+    );
+    const selectedIndex = filteredTasks.findIndex(task => {
+      return task.id === selectedId;
+    });
+
+    this.setState({
+      searchDates,
+      tasks: filteredTasks,
+      selectedTaskIndex: selectedIndex
+    });
+  };
+
+  _clearSearch = () => {
+    const { allTasks } = this.state;
+    this._inputRef.current!.value = "";
+    this.setState({
+      searchDates: { startDate: null, endDate: null },
+      tasks: allTasks
+    });
+  };
+
+  _downloadCSV = () => {
+    const { tasks } = this.state;
+
+    if (tasks.length === 0) {
+      alert("There are no tasks to download! Please adjust your search.");
+    }
+    const fileName = tasks[0].site.name + "-" + tasks[0].id;
+    let rows: any[] = [];
+    const json2csvOptions = { checkSchemaDifferences: true };
+    tasks.forEach(task => {
+      task.entries.forEach(entry => {
+        let entryCopy = Object.assign(
+          { id: task.id, siteName: task.site.name },
+          entry
+        );
+
+        rows.push(entryCopy);
+      });
+    });
+
+    json2csv(
+      rows,
+      (err, csv) => {
+        if (!csv || err) {
+          alert("Something went wrong when trying to download your csv");
+        }
+
+        const dataString = "data:text/csv;charset=utf-8," + csv;
+        const encodedURI = encodeURI(dataString);
+        const link = document.createElement("a");
+        link.setAttribute("href", encodedURI);
+        link.setAttribute("download", `${fileName}.csv`);
+        link.click();
+      },
+      json2csvOptions
+    );
+  };
+
+  _renderSearchPanel = () => {
+    const { focusedInput, searchDates } = this.state;
+    return (
+      <div className="mainview_search_container">
+        <DateRangePicker
+          startDate={searchDates.startDate}
+          startDateId={"startDate"}
+          endDate={searchDates.endDate}
+          endDateId={"endDate"}
+          onDatesChange={this._onDatesChange}
+          focusedInput={focusedInput}
+          onFocusChange={this._onFocusChange}
+          isOutsideRange={() => false}
+          regular={true}
+        />
+        <div className="labelwrapper_row">
+          <input
+            ref={this._inputRef}
+            type="text"
+            onChange={this._onSearchTermChange}
+            placeholder="Search"
+          />
+          <Button
+            className="mainview_clear_search_button"
+            label="Clear Search"
+            onClick={this._clearSearch}
+          />
+          <Button label={"Download CSV"} onClick={this._downloadCSV} />
+        </div>
+      </div>
+    );
+  };
+
   render() {
-    const { selectedTaskIndex } = this.state;
+    const { selectedTaskIndex, showSearch } = this.state;
     return (
       <div className="mainview_content">
         <LabelWrapper
-          label={`ITEMS TO REVIEW: ${this.state.tasks.length}`}
+          label={`${this.props.listLabel}: ${this.state.tasks.length}`}
           className="mainview_tasklist"
+          renderLabelItems={this._renderLabelItems}
         >
+          {!!showSearch && <div>{this._renderSearchPanel()}</div>}
           <TaskList
             onSelect={this._onTaskSelect}
             tasks={this.state.tasks}

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -13,6 +13,7 @@ interface TaskConfig extends TabConfig {
   taskListComponent: string;
   detailsComponent: string;
   listLabel: string;
+  actionable?: boolean;
 }
 
 export interface AppConfig {
@@ -32,6 +33,22 @@ export const defaultConfig: AppConfig = {
       taskListComponent: "AuditTask",
       detailsComponent: "AuditTask",
       listLabel: "ITEMS TO REVIEW",
+      roles: [UserRole.AUDITOR]
+    },
+    Rejected: {
+      taskState: TaskState.REJECTED,
+      taskListComponent: "AuditTask",
+      detailsComponent: "AuditTask",
+      listLabel: "ITEMS TO REVIEW",
+      actionable: false,
+      roles: [UserRole.AUDITOR]
+    },
+    Complete: {
+      taskState: TaskState.COMPLETED,
+      taskListComponent: "AuditTask",
+      detailsComponent: "AuditTask",
+      listLabel: "ITEMS TO REVIEW",
+      actionable: false,
       roles: [UserRole.AUDITOR]
     },
     Payor: {

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -12,6 +12,7 @@ interface TaskConfig extends TabConfig {
   taskState: TaskState;
   taskListComponent: string;
   detailsComponent: string;
+  listLabel: string;
 }
 
 export interface AppConfig {
@@ -27,19 +28,24 @@ export function isCustomPanel(config: TabConfig): config is CustomPanelConfig {
 export const defaultConfig: AppConfig = {
   tabs: {
     Auditor: {
-      panelComponent: "AuditTask",
+      taskState: TaskState.AUDIT,
+      taskListComponent: "AuditTask",
+      detailsComponent: "AuditTask",
+      listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.AUDITOR]
     },
     Payor: {
       taskState: TaskState.PAY,
       taskListComponent: "PayorTask",
       detailsComponent: "PayorTask",
+      listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.PAYOR]
     },
     Operator: {
       taskState: TaskState.FOLLOWUP,
       taskListComponent: "OperatorTask",
       detailsComponent: "OperatorTask",
+      listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.OPERATOR]
     },
     Admin: {


### PR DESCRIPTION
This moves @goldjay's search functionality from the Auditor tab to TaskPanel so that it shows up on all the workflow tabs, and uses that to render the Auditor Tab.

I removed the filtering from the Auditor Tab and just split the todo/complete/rejected filter options out into 3 separate tabs.