### PR TITLE
Fix CSV download

### DIFF
--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -212,7 +212,7 @@ export default class TaskPanel extends React.Component<Props, State> {
     }
     const fileName = tasks[0].site.name + "-" + tasks[0].id;
     let rows: any[] = [];
-    const json2csvOptions = { checkSchemaDifferences: true };
+    const json2csvOptions = { checkSchemaDifferences: false };
     tasks.forEach(task => {
       task.entries.forEach(entry => {
         let entryCopy = Object.assign(


### PR DESCRIPTION
We previously set an option on `json2csv` that would throw an error if some entries had different fields than others. When Philip added a new field, this broke json generation since not everything matched.

This makes the CSV generation more permissive, including all the fields that appear in any record.