### PR TITLE
Search now takes into account the date range

### DIFF
--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -190,13 +190,13 @@ export default class TaskPanel extends React.Component<Props, State> {
 
     return this.state.allTasks.filter(task => {
       return (
-        containsSearchTerm(searchTerm, task.site, filters) ||
-        (task.entries.some(entry => {
-          return containsSearchTerm(searchTerm, entry, filters);
-        }) &&
+        (containsSearchTerm(searchTerm, task.site, filters) ||
           task.entries.some(entry => {
-            return withinDateRange(dateRange, entry);
-          }))
+            return containsSearchTerm(searchTerm, entry, filters);
+          })) &&
+        task.entries.some(entry => {
+          return withinDateRange(dateRange, entry);
+        })
       );
     });
   };


### PR DESCRIPTION
[FEV-1373](https://auderenow.atlassian.net/browse/FEV-1373)

* Changed a weird parenthesis situation and now date is included in the search

Behavior: 
* At least one entry in a pharmacy should fulfill the date range and search / filter parameters
* If one date (start or end) is selected, it should filter the entries accordingly