### PR TITLE
Firestore fixes for admin log events in client

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,6 +12,9 @@ service cloud.firestore {
     match /task_changes/{docId} {
       allow read, write: if true
     }
+    match /admin_log_event/{docId} {
+      allow read, write: if request.auth.token.roles.hasAny(['Admin'])
+    }
     match /metadata/remoteConfig {
       allow read: if true;
     }

--- a/src/Screens/AdminPanel.tsx
+++ b/src/Screens/AdminPanel.tsx
@@ -1,8 +1,7 @@
-import firebase from "firebase";
 import React from "react";
 import { UserRole } from "../sharedtypes";
-import { setRoles } from "../store/corestore";
 import ChangeHistory from "../Components/ChangeHistory";
+import { setRoles, getAdminLogs } from "../store/corestore";
 
 type RoleMap = {
   [roleName in UserRole]: boolean;
@@ -28,8 +27,8 @@ class AdminPanel extends React.Component<Props, State> {
   };
 
   async componentDidMount() {
-    /*    const adminLogs = await this._getAdminLogs();
-    console.log(adminLogs);*/
+    const adminLogs = await getAdminLogs();
+    console.log(adminLogs);
     this.setState({ roleMap: NO_ROLES_MAP });
   }
 
@@ -68,16 +67,6 @@ class AdminPanel extends React.Component<Props, State> {
 
     alert(result);
     this.setState({ email: "", roleMap: NO_ROLES_MAP });
-  };
-
-  _getAdminLogs = async () => {
-    const snap = await firebase
-      .firestore()
-      .collection("admin_log_event")
-      .orderBy("timestamp")
-      .get();
-
-    return snap.docs.map(doc => doc.data());
   };
 
   _renderRoles() {

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -11,7 +11,9 @@ import {
   removeEmptyFieldsInPlace,
   TASK_CHANGE_COLLECTION,
   TaskChangeRecord,
-  TASKS_COLLECTION
+  TASKS_COLLECTION,
+  ADMIN_LOG_EVENT_COLLECTION,
+  AdminLogEvent
 } from "../sharedtypes";
 
 const FIREBASE_CONFIG = {
@@ -111,13 +113,14 @@ export async function getChanges(taskID: string) {
   return changes.docs.map(d => d.data() as TaskChangeRecord);
 }
 
-export async function getAllChanges() {
-  const changes = await firebase
+export async function getAdminLogs(): Promise<AdminLogEvent[]> {
+  const snap = await firebase
     .firestore()
-    .collection(TASK_CHANGE_COLLECTION)
+    .collection(ADMIN_LOG_EVENT_COLLECTION)
     .orderBy("timestamp")
     .get();
-  return changes.docs.map(d => d.data() as TaskChangeRecord);
+
+  return snap.docs.map(doc => doc.data() as AdminLogEvent);
 }
 
 export async function loadTasks(taskState: TaskState): Promise<Task[]> {

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -113,6 +113,16 @@ export async function getChanges(taskID: string) {
   return changes.docs.map(d => d.data() as TaskChangeRecord);
 }
 
+export async function getAllChanges(): Promise<TaskChangeRecord[]> {
+  const snap = await firebase
+    .firestore()
+    .collection(TASK_CHANGE_COLLECTION)
+    .orderBy("timestamp")
+    .get();
+
+  return snap.docs.map(doc => doc.data() as TaskChangeRecord);
+}
+
 export async function getAdminLogs(): Promise<AdminLogEvent[]> {
   const snap = await firebase
     .firestore()


### PR DESCRIPTION
This enables us to work on AdminLogEvents in the client a little more:
* We shouldn't include firebase directly, but instead should import frome firebase/app and also specific firebase modules (like firebase/firestore)
* We should put all firestore access in `corestore` so that we can easily refactor storage in an app-independent way.
* This also updates firestore rules so that the admin panel can actually load history