### PR TITLE
Pass remote config values as props

### DIFF
--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -26,19 +26,19 @@ type State = {
 };
 
 const PanelComponents: {
-  [key: string]: React.ComponentClass<{}>;
+  [key: string]: React.ComponentType<{}>;
 } = {
   Admin: AdminPanel
 };
 
 const ItemComponents: {
-  [key: string]: React.ComponentClass<{ task: Task; isSelected: boolean }>;
+  [key: string]: React.ComponentType<{ task: Task; isSelected: boolean }>;
 } = {
   default: ListItem
 };
 
 const DetailsComponents: {
-  [key: string]: React.ComponentClass<DetailsComponentProps>;
+  [key: string]: React.ComponentType<DetailsComponentProps>;
 } = {
   AuditTask: AuditorDetails,
   PayorTask: PayorDetails,

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -9,32 +9,32 @@ import {
   getBestUserName,
   issuePayments
 } from "../store/corestore";
-import { getConfig } from "../store/remoteconfig";
 import { DetailsComponentProps } from "./TaskPanel";
+import { configuredComponent } from "../util/configuredComponent";
 import "./MainView.css";
 
 type State = {
-  realPayments: boolean;
   paying: boolean;
 };
 
-export class PayorDetails extends React.Component<
-  DetailsComponentProps,
+interface RemoteProps {
+  realPayments: boolean;
+}
+
+class ConfigurablePayorDetails extends React.Component<
+  DetailsComponentProps & RemoteProps,
   State
 > {
   state = {
-    realPayments: false,
     paying: false
   };
 
-  async componentDidMount() {
+  componentDidMount() {
     this.props.registerActionCallback("approve", this._issuePayment);
-    const realPayments = await getConfig("enableRealPayments");
-    this.setState({ realPayments });
   }
 
   _issuePayment = async () => {
-    if (!this.state.realPayments) {
+    if (!this.props.realPayments) {
       await new Promise(res => setTimeout(res, 1000));
       return { success: true };
     }
@@ -123,6 +123,13 @@ export class PayorDetails extends React.Component<
     );
   }
 }
+
+export const PayorDetails = configuredComponent<
+  DetailsComponentProps,
+  RemoteProps
+>(ConfigurablePayorDetails, config => ({
+  realPayments: config.enableRealPayments
+}));
 
 function _getReimbursementTotal(task: Task): number {
   const claimAmounts = task.entries.map(entry => {

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -13,22 +13,13 @@ import { DetailsComponentProps } from "./TaskPanel";
 import { configuredComponent } from "../util/configuredComponent";
 import "./MainView.css";
 
-type State = {
-  paying: boolean;
-};
-
 interface RemoteProps {
   realPayments: boolean;
 }
 
 class ConfigurablePayorDetails extends React.Component<
-  DetailsComponentProps & RemoteProps,
-  State
+  DetailsComponentProps & RemoteProps
 > {
-  state = {
-    paying: false
-  };
-
   componentDidMount() {
     this.props.registerActionCallback("approve", this._issuePayment);
   }

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -42,8 +42,8 @@ type Props = {
   initialSelectedTaskID?: string;
   taskState: TaskState;
   listLabel: string;
-  itemComponent: React.ComponentClass<{ task: Task; isSelected: boolean }>;
-  detailsComponent: React.ComponentClass<DetailsComponentProps>;
+  itemComponent: React.ComponentType<{ task: Task; isSelected: boolean }>;
+  detailsComponent: React.ComponentType<DetailsComponentProps>;
   actions: { [key: string]: ActionConfig };
   registerForTabSelectCallback: (onTabSelect: () => boolean) => void;
 };
@@ -469,7 +469,7 @@ interface DetailWrapperProps {
   task: Task;
   notes: string;
   notesux: ReactNode;
-  detailsComponent: React.ComponentClass<DetailsComponentProps>;
+  detailsComponent: React.ComponentType<DetailsComponentProps>;
   actions: { [key: string]: ActionConfig };
   filters: Filters;
   searchTermGlobal: string;

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -7,16 +7,21 @@ import Button from "../Components/Button";
 import LabelWrapper from "../Components/LabelWrapper";
 import Notes from "../Components/Notes";
 import TaskList from "../Components/TaskList";
-import { Task, TaskChangeRecord, TaskState } from "../sharedtypes";
+import {
+  Task,
+  TaskChangeRecord,
+  TaskState,
+  RemoteConfig
+} from "../sharedtypes";
 import { ActionConfig, defaultConfig, TaskConfig } from "../store/config";
 import {
   changeTaskState,
   getChanges,
   subscribeToTasks
 } from "../store/corestore";
-import { getConfig } from "../store/remoteconfig";
 import debounce from "../util/debounce";
 import { containsSearchTerm, DateRange, withinDateRange } from "../util/search";
+import { configuredComponent } from "../util/configuredComponent";
 import "./MainView.css";
 
 export interface DetailsComponentProps {
@@ -448,7 +453,7 @@ export default class TaskPanel extends React.Component<Props, State> {
         </LabelWrapper>
         <div style={{ width: "100%" }}>
           {selectedTaskIndex >= 0 && (
-            <DetailsWrapper
+            <ConfiguredDetailsWrapper
               task={this.state.tasks[selectedTaskIndex]}
               notesux={notesux}
               notes={notes}
@@ -465,7 +470,7 @@ export default class TaskPanel extends React.Component<Props, State> {
   }
 }
 
-interface DetailWrapperProps {
+interface DetailsWrapperProps {
   task: Task;
   notes: string;
   notesux: ReactNode;
@@ -473,11 +478,12 @@ interface DetailWrapperProps {
   actions: { [key: string]: ActionConfig };
   filters: Filters;
   searchTermGlobal: string;
+  remoteConfig: Partial<RemoteConfig>;
 }
 
 interface DetailsWrapperState {
   buttonsBusy: { [key: string]: boolean };
-  configValues: { [key: string]: boolean };
+  //configValues: { [key: string]: boolean };
 }
 
 interface ActionCallbackResult {
@@ -486,32 +492,12 @@ interface ActionCallbackResult {
 }
 
 class DetailsWrapper extends React.Component<
-  DetailWrapperProps,
+  DetailsWrapperProps,
   DetailsWrapperState
 > {
   state: DetailsWrapperState = {
-    buttonsBusy: {},
-    configValues: {}
+    buttonsBusy: {}
   };
-
-  async componentWillReceiveProps(props: DetailWrapperProps) {
-    const configValues: { [key: string]: boolean } = {};
-    await Promise.all(
-      Object.values(props.actions).map(async action => {
-        if (action.disableOnConfig) {
-          configValues[action.disableOnConfig] = await getConfig(
-            action.disableOnConfig
-          );
-        }
-        if (action.enableOnConfig) {
-          configValues[action.enableOnConfig] = await getConfig(
-            action.enableOnConfig
-          );
-        }
-      })
-    );
-    this.setState({ configValues });
-  }
 
   _actionCallbacks: {
     [key: string]: () => Promise<ActionCallbackResult>;
@@ -556,10 +542,10 @@ class DetailsWrapper extends React.Component<
     const buttons = Object.entries(this.props.actions).filter(
       ([key, action]) => {
         if (action.disableOnConfig) {
-          return !this.state.configValues[action.disableOnConfig];
+          return !this.props.remoteConfig[action.disableOnConfig];
         }
         if (action.enableOnConfig) {
-          return this.state.configValues[action.enableOnConfig];
+          return this.props.remoteConfig[action.enableOnConfig];
         }
         return true;
       }
@@ -588,3 +574,18 @@ class DetailsWrapper extends React.Component<
     );
   }
 }
+
+const ConfiguredDetailsWrapper = configuredComponent<
+  Omit<DetailsWrapperProps, "remoteConfig">,
+  { remoteConfig: Partial<RemoteConfig> }
+>(DetailsWrapper, (config, props) => {
+  const configProps: Partial<RemoteConfig> = {};
+  Object.values(props.actions)
+    .map(action => action.disableOnConfig || action.enableOnConfig)
+    .forEach(configName => {
+      if (configName) {
+        configProps[configName] = config[configName];
+      }
+    });
+  return { remoteConfig: configProps };
+});

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -483,7 +483,6 @@ interface DetailsWrapperProps {
 
 interface DetailsWrapperState {
   buttonsBusy: { [key: string]: boolean };
-  //configValues: { [key: string]: boolean };
 }
 
 interface ActionCallbackResult {

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -1,4 +1,4 @@
-import { UserRole, TaskState } from "../sharedtypes";
+import { UserRole, TaskState, RemoteConfig } from "../sharedtypes";
 
 interface TabConfig {
   roles: UserRole[];
@@ -11,8 +11,8 @@ interface CustomPanelConfig extends TabConfig {
 export interface ActionConfig {
   label: string;
   nextTaskState: TaskState;
-  enableOnConfig?: string;
-  disableOnConfig?: string;
+  enableOnConfig?: keyof RemoteConfig;
+  disableOnConfig?: keyof RemoteConfig;
 }
 
 export interface TaskConfig extends TabConfig {

--- a/src/store/remoteconfig.ts
+++ b/src/store/remoteconfig.ts
@@ -39,3 +39,13 @@ export async function getConfig(key: string) {
   }
   console.error(`Didn't find key ${key} in remoteConfig!`);
 }
+
+export function subscribeToConfigs(
+  callback: (config: RemoteConfig) => void
+): () => void {
+  return firebase
+    .firestore()
+    .collection(METADATA_COLLECTION)
+    .doc(REMOTE_CONFIG_DOC)
+    .onSnapshot(snapshot => callback(snapshot.data() as RemoteConfig));
+}

--- a/src/util/configuredComponent.tsx
+++ b/src/util/configuredComponent.tsx
@@ -8,7 +8,7 @@ interface ConfiguredComponentState {
 
 export function configuredComponent<Props, RemoteProps>(
   Component: React.ComponentType<Props & RemoteProps>,
-  p: (config: RemoteConfig, props: Props) => RemoteProps
+  getProps: (config: RemoteConfig, props: Props) => RemoteProps
 ): React.ComponentType<Props> {
   return class extends React.Component<Props, ConfiguredComponentState> {
     state: ConfiguredComponentState = {};
@@ -26,7 +26,7 @@ export function configuredComponent<Props, RemoteProps>(
     }
 
     render() {
-      const configProps = p(
+      const configProps = getProps(
         this.state.config || DEFAULT_REMOTE_CONFIG,
         this.props
       );

--- a/src/util/configuredComponent.tsx
+++ b/src/util/configuredComponent.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { RemoteConfig, DEFAULT_REMOTE_CONFIG } from "../sharedtypes";
+import { subscribeToConfigs } from "../store/remoteconfig";
+
+interface ConfiguredComponentState {
+  config?: RemoteConfig;
+}
+
+export function configuredComponent<Props, RemoteProps>(
+  Component: React.ComponentType<Props & RemoteProps>,
+  p: (config: RemoteConfig, props: Props) => RemoteProps
+): React.ComponentType<Props> {
+  return class extends React.Component<Props, ConfiguredComponentState> {
+    state: ConfiguredComponentState = {};
+
+    private unsubscribe?: () => void;
+
+    componentDidMount() {
+      this.unsubscribe = subscribeToConfigs(config => {
+        this.setState({ config });
+      });
+    }
+
+    componentWillUnmount() {
+      this.unsubscribe && this.unsubscribe();
+    }
+
+    render() {
+      const configProps = p(
+        this.state.config || DEFAULT_REMOTE_CONFIG,
+        this.props
+      );
+      return <Component {...this.props} {...configProps} />;
+    }
+  };
+}


### PR DESCRIPTION
This adds a `configureComponent()` method that is basically the equivalent of `redux-react`'s `connect()` method, but it ties a component to remote config values rather than redux state. It takes in a component that accepts one or more props that depend on remote config values, a method to map remote config state to those props, and returns a component that only requires the remaining props.

I was able to remove the code in the Payor Details component that explicitly fetched the "realPayments" remote config value, and instead it just accepts it as a prop. The TaskPanel changes were a bit less clean, since the values it needs are based on the config, but it also works there.

I started this PR to address @auderephilip's comment [here](https://github.com/AudereNow/flows/commit/09ba63a792933c3dbb55c00a3ac0740864acaf0f#r35739927), and got a little carried away.