### PR TITLE
Update URL history with permalinks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,9 +37,7 @@ class App extends React.Component<Props, State> {
     const taskID = routeProps.match.params.id;
     const tabMatches = routeProps.location.pathname.match(/\/(.+?)\//);
     const tabName = tabMatches![1];
-    return (
-      <MainView key={taskID} selectedTaskID={taskID} startingTab={tabName} />
-    );
+    return <MainView selectedTaskID={taskID} startingTab={tabName} />;
   };
 
   render() {
@@ -48,7 +46,13 @@ class App extends React.Component<Props, State> {
         <Router>
           <Switch>
             <Route
-              path={["/auditor/:id", "/payor/:id", "/operator/:id"]}
+              path={[
+                "/auditor/:id",
+                "/payor/:id",
+                "/operator/:id",
+                "/rejected/:id",
+                "/completed/:id"
+              ]}
               render={this._renderLinkedMainView}
             />
             <Route>

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -2,6 +2,7 @@ import { UserRole, TaskState, RemoteConfig } from "../sharedtypes";
 
 interface TabConfig {
   roles: UserRole[];
+  baseUrl: string;
 }
 
 interface CustomPanelConfig extends TabConfig {
@@ -41,6 +42,7 @@ export const defaultConfig: AppConfig = {
       detailsComponent: "AuditTask",
       listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.AUDITOR],
+      baseUrl: "/auditor",
       actions: {
         decline: {
           label: "Decline",
@@ -58,6 +60,7 @@ export const defaultConfig: AppConfig = {
       detailsComponent: "PayorTask",
       listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.PAYOR],
+      baseUrl: "/payor",
       actions: {
         decline: {
           label: "Decline Payment",
@@ -81,6 +84,7 @@ export const defaultConfig: AppConfig = {
       detailsComponent: "OperatorTask",
       listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.OPERATOR],
+      baseUrl: "/operator",
       actions: {
         decline: {
           label: "Reject",
@@ -98,19 +102,22 @@ export const defaultConfig: AppConfig = {
       detailsComponent: "AuditTask",
       listLabel: "ITEMS",
       actions: {},
-      roles: [UserRole.AUDITOR]
+      roles: [UserRole.AUDITOR],
+      baseUrl: "/rejected"
     },
-    Complete: {
+    Completed: {
       taskState: TaskState.COMPLETED,
       taskListComponent: "default",
       detailsComponent: "AuditTask",
       listLabel: "ITEMS",
       actions: {},
-      roles: [UserRole.AUDITOR]
+      roles: [UserRole.AUDITOR],
+      baseUrl: "/completed"
     },
     Admin: {
       panelComponent: "Admin",
-      roles: [UserRole.ADMIN]
+      roles: [UserRole.ADMIN],
+      baseUrl: "/admin"
     }
   }
 };


### PR DESCRIPTION
Keep the browser location updated with permalinks whenever you select tabs or tasks so that copy/paste is enabled between users/uses.

- Removed class member that tracked whether to respect `initialSelectedTaskID` in favor of replicating prop into state (which is apparently React's #2 recommendation of how to handle that issue).  This also removed the need to re-key MainView.
- Added `baseUrl` to each tab's config.
- Changed tab name to `Completed` in order to match the case of `Rejected`.
- Enabled /completed and /rejected URLs to be permalinks

![URL Preservation](https://user-images.githubusercontent.com/42978089/68178891-70fc0600-ff42-11e9-852f-dfb5a2a64658.gif)
