### PR TITLE
Show previous tasks from the same pharmacy in payor details

### DIFF
--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -74,6 +74,10 @@
   flex: 4;
 }
 
+.mainview_details_text {
+  margin: 10px;
+}
+
 .mainview_actions_so_far_header {
   margin-top: 12px;
   margin: 10px;

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -145,6 +145,21 @@ export async function loadTasks(taskState: TaskState): Promise<Task[]> {
   return taskSnapshot.docs.map(doc => (doc.data() as unknown) as Task);
 }
 
+export async function loadPreviousTasks(
+  siteName: string,
+  currentId: string
+): Promise<Task[]> {
+  const states = Object.values(TaskState);
+  return (await firebase
+    .firestore()
+    .collection(TASKS_COLLECTION)
+    .where("site.name", "==", siteName)
+    .get()).docs
+    .map(doc => doc.data() as Task)
+    .sort((t1, t2) => states.indexOf(t1.state) - states.indexOf(t2.state))
+    .filter(t => t.id !== currentId);
+}
+
 export async function setRoles(
   email: string,
   roles: UserRole[]


### PR DESCRIPTION
Previous tasks are collapsed by default. Expanded, you get a simple table:
![image](https://user-images.githubusercontent.com/1070243/68439738-9fb1f080-017d-11ea-8c6a-5241cc847ece.png)
