### PR TITLE
Use React Context to propagate search terms

### DIFF
--- a/src/Components/ImageRow.tsx
+++ b/src/Components/ImageRow.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { ClaimEntryFilters } from "../Screens/TaskPanel";
 import "./ImageRow.css";
 import TextItem, { TextData } from "./TextItem";
 import ZoomableImage from "./ZoomableImage";
 
 interface Props {
   images: Array<string | ImageData>;
-  searchTermGlobal?: string;
-  filters: ClaimEntryFilters;
 }
 
 interface ImageData {
@@ -29,8 +26,6 @@ const ImageRow = (props: Props) => {
                 <TextItem
                   className="imagerow_label"
                   data={(data as ImageData).label}
-                  filters={props.filters}
-                  searchTermGlobal={props.searchTermGlobal}
                   valueOnly={true}
                 />
               )}

--- a/src/Components/TextItem.tsx
+++ b/src/Components/TextItem.tsx
@@ -8,18 +8,24 @@ export interface TextData {
   value: string;
 }
 
+export const SearchContext = React.createContext({
+  searchTermGlobal: "",
+  filters: {}
+});
+
 interface Props {
   data: TextData;
-  searchTermGlobal?: string;
   valueOnly?: boolean; // true = no display key or unstyled display key; false = styled display key
   className?: string;
-  filters?: ClaimEntryFilters;
 }
 
-function highlight(props: Props) {
+function highlight(
+  props: Props,
+  searchTerm: string,
+  filters: ClaimEntryFilters
+) {
   const { searchKey, value } = props.data;
-  const searchTerm = props.searchTermGlobal;
-  let filters = props.filters || {};
+  filters = filters || {};
   if (!filters || !Object.values(filters).some(value => !!value)) {
     filters = { patient: true, name: true, patientID: true, item: true };
   }
@@ -43,19 +49,24 @@ function highlight(props: Props) {
   });
 }
 
-const TextItem = (props: Props) => {
-  const { displayKey } = props.data;
-  return (
-    <div className="textitem_container">
-      {!props.valueOnly && !!displayKey && (
-        <span className="textitem_key">{displayKey + ":"}</span>
-      )}
-      <div className={props.className}>
-        {props.valueOnly && !!displayKey && displayKey + ": "}
-        {!!props.searchTermGlobal ? highlight(props) : props.data.value}
-      </div>
-    </div>
-  );
-};
+export default class TextItem extends React.Component<Props> {
+  static contextType = SearchContext;
 
-export default TextItem;
+  render() {
+    const { displayKey } = this.props.data;
+    const { searchTermGlobal, filters } = this.context;
+    return (
+      <div className="textitem_container">
+        {!this.props.valueOnly && !!displayKey && (
+          <span className="textitem_key">{displayKey + ":"}</span>
+        )}
+        <div className={this.props.className}>
+          {this.props.valueOnly && !!displayKey && displayKey + ": "}
+          {!!searchTermGlobal
+            ? highlight(this.props, searchTermGlobal, filters)
+            : this.props.data.value}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -5,7 +5,7 @@ import "react-tabs/style/react-tabs.css";
 import Button from "../Components/Button";
 import ImageRow from "../Components/ImageRow";
 import LabelWrapper from "../Components/LabelWrapper";
-import TextItem from "../Components/TextItem";
+import TextItem, { SearchContext } from "../Components/TextItem";
 import { ClaimEntry } from "../sharedtypes";
 import debounce from "../util/debounce";
 import { containsSearchTerm } from "../util/search";
@@ -33,6 +33,8 @@ export class AuditorDetails extends React.Component<
       MIN_SAMPLES
     )
   };
+
+  static contextType = SearchContext;
 
   componentDidMount() {
     this.props.registerActionCallback("approve", this._onApprove);
@@ -87,7 +89,6 @@ export class AuditorDetails extends React.Component<
 
   _renderClaimEntryDetails = (entry: ClaimEntry) => {
     const { searchTermDetails } = this.state;
-    const { filters, searchTermGlobal } = this.props;
     let patientProps = [];
     if (!!entry.patientAge) patientProps.push(entry.patientAge);
     if (!!entry.patientSex && entry.patientSex!.length > 0)
@@ -111,8 +112,6 @@ export class AuditorDetails extends React.Component<
       <LabelWrapper key={JSON.stringify(entry)}>
         <TextItem
           data={{ displayKey: "Date", searchKey: "date", value: date }}
-          filters={filters}
-          searchTermGlobal={searchTermGlobal}
         />
         <div style={{ display: "flex", flexDirection: "row" }}>
           <TextItem
@@ -121,15 +120,9 @@ export class AuditorDetails extends React.Component<
               searchKey: "patient",
               value: patient
             }}
-            filters={filters}
-            searchTermGlobal={searchTermGlobal}
           />
         </div>
-        <ImageRow
-          filters={filters}
-          searchTermGlobal={searchTermGlobal}
-          images={this._extractImages(entry)}
-        />
+        <ImageRow images={this._extractImages(entry)} />
       </LabelWrapper>
     );
   };
@@ -146,9 +139,9 @@ export class AuditorDetails extends React.Component<
   };
 
   render() {
-    const showAllEntries =
-      !!this.props.searchTermGlobal || this.state.showAllEntries;
-    const { task, searchTermGlobal, notesux } = this.props;
+    const { searchTermGlobal } = this.context;
+    const showAllEntries = !!searchTermGlobal || this.state.showAllEntries;
+    const { task, notesux } = this.props;
 
     const samples = task.entries.slice(0, this.state.numSamples);
     const remaining = task.entries.length - this.state.numSamples;
@@ -165,8 +158,6 @@ export class AuditorDetails extends React.Component<
               searchKey: "name",
               value: task.site.name
             }}
-            filters={this.props.filters}
-            searchTermGlobal={searchTermGlobal}
           />
 
           <input

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -42,7 +42,6 @@ export class OperatorDetails extends React.Component<DetailsComponentProps> {
       patientProps.push(entry.patientSex);
     const patientInfo =
       patientProps.length > 0 ? `(${patientProps.join(", ")})` : "";
-    const { searchTermGlobal, filters } = this.props;
 
     return (
       <LabelWrapper key={patientInfo}>
@@ -52,8 +51,6 @@ export class OperatorDetails extends React.Component<DetailsComponentProps> {
             searchKey: "date",
             value: new Date(entry.timestamp).toLocaleDateString()
           }}
-          filters={filters}
-          searchTermGlobal={searchTermGlobal}
         />
         <TextItem
           data={{
@@ -61,20 +58,13 @@ export class OperatorDetails extends React.Component<DetailsComponentProps> {
             searchKey: "patient",
             value: `${entry.patientFirstName} ${entry.patientLastName} ${patientInfo}`
           }}
-          filters={filters}
-          searchTermGlobal={searchTermGlobal}
         />
-        <ImageRow
-          searchTermGlobal={searchTermGlobal}
-          filters={filters}
-          images={this._extractImages(entry)}
-        />
+        <ImageRow images={this._extractImages(entry)} />
       </LabelWrapper>
     );
   };
 
   render() {
-    const { filters, searchTermGlobal } = this.props;
     return (
       <LabelWrapper className="mainview_details" label="DETAILS">
         <TextItem
@@ -83,8 +73,6 @@ export class OperatorDetails extends React.Component<DetailsComponentProps> {
             searchKey: "name",
             value: this.props.task.site.name
           }}
-          filters={filters}
-          searchTermGlobal={searchTermGlobal}
         />
         {this.props.task.entries.map(this._renderClaimEntryDetails)}
         {this.props.notesux}

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -91,7 +91,7 @@ class ConfigurablePayorDetails extends React.Component<
   };
 
   render() {
-    const { filters, searchTermGlobal, task, notesux } = this.props;
+    const { task, notesux } = this.props;
     const claimsTotal = _getReimbursementTotal(task);
 
     let cleanedData: any[] = [];
@@ -129,13 +129,11 @@ class ConfigurablePayorDetails extends React.Component<
     return (
       <LabelWrapper className="mainview_details" label="DETAILS">
         <TextItem
-          searchTermGlobal={searchTermGlobal}
           data={{
             displayKey: "Pharmacy",
             searchKey: "name",
             value: task.site.name
           }}
-          filters={filters}
         />
         {!!task.site.phone && (
           <TextItem
@@ -144,18 +142,14 @@ class ConfigurablePayorDetails extends React.Component<
               searchKey: "phone",
               value: task.site.phone
             }}
-            filters={filters}
-            searchTermGlobal={searchTermGlobal}
           />
         )}
         <TextItem
-          searchTermGlobal={searchTermGlobal}
           data={{
             displayKey: "Total Reimbursement",
             searchKey: "reimbursement",
             value: formatCurrency(claimsTotal)
           }}
-          filters={filters}
         />
         <DataTable data={cleanedData} />
         <Button

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -9,6 +9,7 @@ import CheckBox from "../Components/CheckBox";
 import LabelWrapper from "../Components/LabelWrapper";
 import Notes from "../Components/Notes";
 import TaskList from "../Components/TaskList";
+import { SearchContext } from "../Components/TextItem";
 import {
   RemoteConfig,
   Task,
@@ -34,8 +35,6 @@ export interface DetailsComponentProps {
     key: string,
     callback: () => Promise<ActionCallbackResult>
   ) => void;
-  searchTermGlobal?: string;
-  filters: ClaimEntryFilters;
 }
 
 export interface SiteFilters {
@@ -438,7 +437,7 @@ class TaskPanel extends React.Component<Props, State> {
   };
 
   render() {
-    const { selectedTaskIndex, searchTermGlobal, notes } = this.state;
+    const { selectedTaskIndex, notes } = this.state;
     const actionable = Object.keys(this.props.actions).length > 0;
     const notesux =
       selectedTaskIndex >= 0 ? (
@@ -451,35 +450,40 @@ class TaskPanel extends React.Component<Props, State> {
       ) : null;
 
     return (
-      <div className="mainview_content">
-        <LabelWrapper
-          label={`${this.props.listLabel}: ${this.state.tasks.length}`}
-          renderLabelItems={this._renderLabelItems}
-          searchPanel={this._renderSearchPanel()}
-        >
-          <TaskList
-            onSelect={this._onTaskSelect}
-            tasks={this.state.tasks}
-            renderItem={this._renderTaskListItem}
-            selectedItem={selectedTaskIndex}
-            className="mainview_tasklist"
-          />
-        </LabelWrapper>
-        <div style={{ width: "100%" }}>
-          {selectedTaskIndex >= 0 && (
-            <ConfiguredDetailsWrapper
-              task={this.state.tasks[selectedTaskIndex]}
-              notesux={notesux}
-              notes={notes}
-              detailsComponent={this.props.detailsComponent}
-              actions={this.props.actions}
-              filters={this.state.filters}
-              key={this.state.tasks[selectedTaskIndex].id}
-              searchTermGlobal={searchTermGlobal}
+      <SearchContext.Provider
+        value={{
+          searchTermGlobal: this.state.searchTermGlobal,
+          filters: this.state.filters
+        }}
+      >
+        <div className="mainview_content">
+          <LabelWrapper
+            label={`${this.props.listLabel}: ${this.state.tasks.length}`}
+            renderLabelItems={this._renderLabelItems}
+            searchPanel={this._renderSearchPanel()}
+          >
+            <TaskList
+              onSelect={this._onTaskSelect}
+              tasks={this.state.tasks}
+              renderItem={this._renderTaskListItem}
+              selectedItem={selectedTaskIndex}
+              className="mainview_tasklist"
             />
-          )}
+          </LabelWrapper>
+          <div style={{ width: "100%" }}>
+            {selectedTaskIndex >= 0 && (
+              <ConfiguredDetailsWrapper
+                task={this.state.tasks[selectedTaskIndex]}
+                notesux={notesux}
+                notes={notes}
+                detailsComponent={this.props.detailsComponent}
+                actions={this.props.actions}
+                key={this.state.tasks[selectedTaskIndex].id}
+              />
+            )}
+          </div>
         </div>
-      </div>
+      </SearchContext.Provider>
     );
   }
 }
@@ -492,8 +496,6 @@ interface DetailsWrapperProps {
   notesux: ReactNode;
   detailsComponent: React.ComponentType<DetailsComponentProps>;
   actions: { [key: string]: ActionConfig };
-  filters: ClaimEntryFilters;
-  searchTermGlobal: string;
   remoteConfig: Partial<RemoteConfig>;
 }
 
@@ -571,8 +573,6 @@ class DetailsWrapper extends React.Component<
         notesux={this.props.notesux}
         key={this.props.task.id}
         registerActionCallback={this._registerActionCallback}
-        filters={this.props.filters}
-        searchTermGlobal={this.props.searchTermGlobal}
       >
         <div className="mainview_button_row">
           {buttons.map(([key, actionConfig]) => (


### PR DESCRIPTION
This adds a `SearchContext` that is provided by `TaskPanel` and consumed by `TextItem`, so that we don't have to pass `searchTermGlobal` and `filters` down through intermediate components.