### PR TITLE
Merge change history admin logs

### DIFF
--- a/src/Components/SearchableTable.tsx
+++ b/src/Components/SearchableTable.tsx
@@ -3,7 +3,7 @@ import moment from "moment";
 import React from "react";
 import ReactTable from "react-table";
 import "react-table/react-table.css";
-import { AdminLogRow, ChangeRow } from "../Screens/AdminPanel";
+import { HistoryRow } from "../Screens/AdminPanel";
 import debounce from "../util/debounce";
 import { containsSearchTerm } from "../util/search";
 import Button from "./Button";
@@ -12,7 +12,7 @@ import "./SearchableTable.css";
 
 type Props = {
   tableColumns: any[];
-  allData: ChangeRow[] | AdminLogRow[];
+  allData: HistoryRow[];
   downloadPrefix: string;
 };
 type State = {

--- a/src/Screens/AdminPanel.tsx
+++ b/src/Screens/AdminPanel.tsx
@@ -20,35 +20,33 @@ const NO_ROLES_MAP: RoleMap = {
 
 type Props = {};
 type State = {
-  allChanges: ChangeRow[];
-  allAdminLogs: AdminLogRow[];
+  allHistory: HistoryRow[];
   email: string;
   roleMap: RoleMap;
 };
 
-export type ChangeRow = {
+export type HistoryRow = {
   taskID: string;
+  userID?: string;
   timestamp: string;
   description: string;
   notes?: string;
 };
 
-export type AdminLogRow = {
-  userID: string;
-  desc: string;
-  timestamp: string;
-  userName: string;
-};
-
-const CHANGE_HISTORY_TABLE_COLUMNS = [
-  { Header: "Task ID", accessor: "taskID", minWidth: 100 },
+const HISTORY_TABLE_COLUMNS = [
+  { Header: "Task ID", accessor: "taskID", minWidth: 90 },
+  { Header: "User ID", accessor: "userID", minWidth: 110 },
   {
     Header: "Time",
     accessor: "timestamp",
     Cell: (props: RowRenderProps) => renderTooltippedTime(props.value),
     minWidth: 60
   },
-  { Header: "Description", accessor: "description", minWidth: 150 },
+  {
+    Header: "Description",
+    accessor: "description",
+    minWidth: 150
+  },
   {
     Header: "Notes",
     accessor: "notes",
@@ -57,22 +55,9 @@ const CHANGE_HISTORY_TABLE_COLUMNS = [
   }
 ];
 
-const ADMIN_LOGS_TABLE_COLUMNS = [
-  { Header: "ID", accessor: "userID", minWidth: 200 },
-  { Header: "Name", accessor: "userName", minWidth: 100 },
-  { Header: "Description", accessor: "desc", minWidth: 150 },
-  {
-    Header: "Time",
-    accessor: "timestamp",
-    Cell: (props: RowRenderProps) => renderTooltippedTime(props.value),
-    minWidth: 100
-  }
-];
-
 class AdminPanel extends React.Component<Props, State> {
   state: State = {
-    allAdminLogs: [],
-    allChanges: [],
+    allHistory: [],
     email: "",
     roleMap: NO_ROLES_MAP
   };
@@ -85,8 +70,9 @@ class AdminPanel extends React.Component<Props, State> {
     this._fetchedAllData = true;
     this.setState({
       roleMap: NO_ROLES_MAP,
-      allChanges: this._recordsToChangeRows(allChanges),
-      allAdminLogs: this._recordsToAdminLogRows(allAdminLogs)
+      allHistory: this._recordsToChangeRows(allChanges).concat(
+        this._recordsToAdminLogRows(allAdminLogs)
+      )
     });
   }
 
@@ -146,7 +132,7 @@ class AdminPanel extends React.Component<Props, State> {
     return <div>{roleBoxes}</div>;
   }
 
-  _recordsToChangeRows = (records: TaskChangeRecord[]): ChangeRow[] => {
+  _recordsToChangeRows = (records: TaskChangeRecord[]): HistoryRow[] => {
     return records.map(r => {
       return {
         taskID: r.taskID,
@@ -159,10 +145,11 @@ class AdminPanel extends React.Component<Props, State> {
     });
   };
 
-  _recordsToAdminLogRows = (records: any[]): AdminLogRow[] => {
+  _recordsToAdminLogRows = (records: any[]): HistoryRow[] => {
     return records.map(r => {
       return {
-        desc: r.desc,
+        description: r.desc,
+        taskID: "",
         timestamp: new Date(r.timestamp).toLocaleDateString(),
         userID: r.user.id,
         userName: r.user.name
@@ -171,30 +158,21 @@ class AdminPanel extends React.Component<Props, State> {
   };
 
   render() {
-    const { allChanges, allAdminLogs } = this.state;
+    const { allHistory } = this.state;
+
     return (
       <div className="mainview_admin_panel">
         <Tabs>
           <TabList>
-            <Tab>Change History</Tab>
-            <Tab>Admin Logs</Tab>
+            <Tab>History</Tab>
             <Tab>User Roles</Tab>
           </TabList>
           <TabPanel>
             {this._fetchedAllData && (
               <SearchableTable
                 downloadPrefix={"changeHistory_"}
-                allData={allChanges}
-                tableColumns={CHANGE_HISTORY_TABLE_COLUMNS}
-              />
-            )}
-          </TabPanel>
-          <TabPanel>
-            {this._fetchedAllData && (
-              <SearchableTable
-                downloadPrefix={"adminLogs_"}
-                allData={allAdminLogs}
-                tableColumns={ADMIN_LOGS_TABLE_COLUMNS}
+                allData={allHistory}
+                tableColumns={HISTORY_TABLE_COLUMNS}
               />
             )}
           </TabPanel>

--- a/src/Screens/AdminPanel.tsx
+++ b/src/Screens/AdminPanel.tsx
@@ -35,7 +35,6 @@ export type HistoryRow = {
 
 const HISTORY_TABLE_COLUMNS = [
   { Header: "Task ID", accessor: "taskID", minWidth: 90 },
-  { Header: "User ID", accessor: "userID", minWidth: 110 },
   {
     Header: "Time",
     accessor: "timestamp",
@@ -151,7 +150,6 @@ class AdminPanel extends React.Component<Props, State> {
         description: r.desc,
         taskID: "",
         timestamp: new Date(r.timestamp).toLocaleDateString(),
-        userID: r.user.id,
         userName: r.user.name
       };
     });

--- a/src/Screens/AdminPanel.tsx
+++ b/src/Screens/AdminPanel.tsx
@@ -34,22 +34,27 @@ export type ChangeRow = {
 };
 
 export type AdminLogRow = {
+  userID: string;
   desc: string;
   timestamp: string;
-  userID: string;
   userName: string;
 };
 
 const CHANGE_HISTORY_TABLE_COLUMNS = [
-  { Header: "Task ID", accessor: "taskID", minWidth: 150 },
+  { Header: "Task ID", accessor: "taskID", minWidth: 100 },
   {
     Header: "Time",
     accessor: "timestamp",
     Cell: (props: RowRenderProps) => renderTooltippedTime(props.value),
-    minWidth: 100
+    minWidth: 60
   },
-  { Header: "Description", accessor: "description", minWidth: 450 },
-  { Header: "Notes", accessor: "notes", minWidth: 200 }
+  { Header: "Description", accessor: "description", minWidth: 150 },
+  {
+    Header: "Notes",
+    accessor: "notes",
+    minWidth: 200,
+    style: { whiteSpace: "unset" }
+  }
 ];
 
 const ADMIN_LOGS_TABLE_COLUMNS = [


### PR DESCRIPTION
[FEV-1465](https://auderenow.atlassian.net/browse/FEV-1465)
[FEV-1433](https://auderenow.atlassian.net/browse/FEV-1433)

* Allow notes text to wrap around instead of being cut off
NOTE: I could also do this for description, but the description for rejected CSVs is very long so it's not practical
* Merged the two admin tables together


<img width="1674" alt="Screen Shot 2019-11-19 at 12 34 39 PM" src="https://user-images.githubusercontent.com/15152013/69135008-75d7c280-0ac9-11ea-8440-5bdb173d901f.png">
