### PR TITLE
FEV-1313 Add pharmacy docs in firestore and editable pharmacy notes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -15,6 +15,9 @@ service cloud.firestore {
     match /admin_log_event/{docId} {
       allow read, write: if request.auth.token.roles.hasAny(['Admin'])
     }
+    match /pharmacies/{name} {
+      allow read, write: if request.auth.token.roles.hasAny(['Admin', 'Auditor', 'Payor', 'Operator'])
+    }
     match /metadata/remoteConfig {
       allow read: if true;
     }

--- a/src/Components/PharmacyInfo.css
+++ b/src/Components/PharmacyInfo.css
@@ -1,0 +1,3 @@
+.pharmacy_detail {
+  margin: 5px
+}

--- a/src/Components/PharmacyInfo.tsx
+++ b/src/Components/PharmacyInfo.tsx
@@ -98,7 +98,7 @@ class PharmacyInfoHelper extends React.Component<Props, State> {
             </div>
           ) : (
             <div className="pharmacy_detail">
-              Notes: {this.state.pharmacy.notes}{" "}
+              {`Notes: ${this.state.pharmacy.notes} `}
               <button onClick={this._onNotesEdit}>Edit</button>
             </div>
           ))}

--- a/src/Components/PharmacyInfo.tsx
+++ b/src/Components/PharmacyInfo.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { Pharmacy } from "../sharedtypes";
+import {
+  subscribeToPharmacyDetails,
+  setPharmacyDetails
+} from "../store/corestore";
+import TextItem from "./TextItem";
+import "./PharmacyInfo.css";
+
+const DEFAULT_PHARMACY: Pharmacy = {
+  opsOwners: []
+};
+
+interface Props {
+  name: string;
+}
+
+export class PharmacyInfo extends React.Component<Props> {
+  render() {
+    return <PharmacyInfoHelper name={this.props.name} key={this.props.name} />;
+  }
+}
+
+interface State {
+  pharmacy?: Pharmacy;
+  editing: boolean;
+  saving: boolean;
+  editedNotes?: string;
+}
+class PharmacyInfoHelper extends React.Component<Props, State> {
+  state: State = {
+    editing: false,
+    saving: false
+  };
+
+  componentDidMount() {
+    subscribeToPharmacyDetails(this.props.name, pharmacy => {
+      if (pharmacy === undefined) {
+        pharmacy = DEFAULT_PHARMACY;
+      }
+      this.setState({ pharmacy });
+    });
+  }
+
+  _onNotesEdit = () => {
+    if (!this.state.pharmacy) {
+      return;
+    }
+    this.setState({ editing: true, editedNotes: this.state.pharmacy.notes });
+  };
+
+  _onNotesSave = async () => {
+    if (!this.state.pharmacy) {
+      return;
+    }
+    this.setState({ saving: true });
+    await setPharmacyDetails(this.props.name, {
+      ...this.state.pharmacy,
+      notes: this.state.editedNotes
+    });
+    this.setState({ editing: false, saving: false });
+  };
+
+  _onNotesChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    this.setState({
+      editedNotes: event.target.value
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <TextItem
+          data={{
+            displayKey: "Pharmacy",
+            searchKey: "name",
+            value: this.props.name
+          }}
+        />
+        {this.state.pharmacy &&
+          (this.state.editing ? (
+            <div className="pharmacy_detail">
+              <div>Notes:</div>
+              <textarea
+                readOnly={this.state.saving}
+                onChange={this._onNotesChange}
+              >
+                {this.state.pharmacy.notes}
+              </textarea>
+              <div>
+                <button
+                  onClick={this._onNotesSave}
+                  disabled={this.state.saving}
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="pharmacy_detail">
+              Notes: {this.state.pharmacy.notes}{" "}
+              <button onClick={this._onNotesEdit}>Edit</button>
+            </div>
+          ))}
+      </div>
+    );
+  }
+}

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -5,6 +5,7 @@ import "react-tabs/style/react-tabs.css";
 import Button from "../Components/Button";
 import ImageRow from "../Components/ImageRow";
 import LabelWrapper from "../Components/LabelWrapper";
+import { PharmacyInfo } from "../Components/PharmacyInfo";
 import TextItem, { SearchContext } from "../Components/TextItem";
 import { ClaimEntry } from "../sharedtypes";
 import debounce from "../util/debounce";
@@ -151,15 +152,8 @@ export class AuditorDetails extends React.Component<
         className="mainview_details"
         label="DETAILS"
       >
+        <PharmacyInfo name={task.site.name} />
         <div className="mainview_spaced_row">
-          <TextItem
-            data={{
-              displayKey: "Pharmacy",
-              searchKey: "name",
-              value: task.site.name
-            }}
-          />
-
           <input
             type="text"
             onChange={this._handleSearchTermDetailsChange}

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -11,6 +11,7 @@ export const ADMIN_LOG_EVENT_COLLECTION = "admin_log_event";
 export const TASK_CHANGE_COLLECTION = "task_changes";
 export const METADATA_COLLECTION = "metadata";
 export const TASKS_COLLECTION = "tasks";
+export const PHARMACY_COLLECTION = "pharmacies";
 
 export enum TaskState {
   CSV = "CSV",
@@ -98,6 +99,11 @@ export type UploaderInfo = {
 export type User = {
   name: string;
   id: string;
+};
+
+export type Pharmacy = {
+  notes?: string;
+  opsOwners: string[];
 };
 
 // This is used to log isuses that the Admin needs to see

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -3,17 +3,19 @@ import "firebase/auth";
 import "firebase/firestore";
 import "firebase/functions";
 import {
-  UserRole,
-  Task,
-  TaskState,
-  PaymentRecipient,
   ACTIVE_TASK_COLLECTION,
-  removeEmptyFieldsInPlace,
-  TASK_CHANGE_COLLECTION,
-  TaskChangeRecord,
-  TASKS_COLLECTION,
   ADMIN_LOG_EVENT_COLLECTION,
-  AdminLogEvent
+  AdminLogEvent,
+  Pharmacy,
+  PHARMACY_COLLECTION,
+  PaymentRecipient,
+  TASKS_COLLECTION,
+  TASK_CHANGE_COLLECTION,
+  Task,
+  TaskChangeRecord,
+  TaskState,
+  UserRole,
+  removeEmptyFieldsInPlace
 } from "../sharedtypes";
 
 const FIREBASE_CONFIG = {
@@ -260,4 +262,28 @@ export function subscribeActiveTasks(
       onActiveTasksChanged(actives);
     });
   return unsubscriber;
+}
+
+export function subscribeToPharmacyDetails(
+  pharmacyId: string,
+  callback: (pharmacy: Pharmacy) => void
+): () => void {
+  return firebase
+    .firestore()
+    .collection(PHARMACY_COLLECTION)
+    .doc(pharmacyId)
+    .onSnapshot(snapshot => {
+      callback(snapshot.data() as Pharmacy);
+    });
+}
+
+export async function setPharmacyDetails(
+  pharmacyId: string,
+  pharmacy: Pharmacy
+) {
+  await firebase
+    .firestore()
+    .collection(PHARMACY_COLLECTION)
+    .doc(pharmacyId)
+    .set(pharmacy);
 }


### PR DESCRIPTION
Adds a new collection of pharmacy docs under the `pharmacies` collection in firestore. First use for this is an editable notes field for a pharmacy that persists across tasks.

![image](https://user-images.githubusercontent.com/1070243/69144901-724e3680-0add-11ea-988d-6c4e9424de9b.png)

![image](https://user-images.githubusercontent.com/1070243/69144920-7da16200-0add-11ea-9bb1-68a8498358df.png)
