### PR TITLE
FEV-1461 Filter tasks by pharmacy owners

### DIFF
--- a/src/Components/PharmacyInfo.css
+++ b/src/Components/PharmacyInfo.css
@@ -1,3 +1,7 @@
 .pharmacy_detail {
   margin: 5px
 }
+
+.pharmacy_helptext {
+  font-size: small;
+}

--- a/src/Components/PharmacyInfo.tsx
+++ b/src/Components/PharmacyInfo.tsx
@@ -8,7 +8,8 @@ import TextItem from "./TextItem";
 import "./PharmacyInfo.css";
 
 const DEFAULT_PHARMACY: Pharmacy = {
-  opsOwners: []
+  notes: "",
+  owners: []
 };
 
 interface Props {
@@ -23,13 +24,12 @@ export class PharmacyInfo extends React.Component<Props> {
 
 interface State {
   pharmacy?: Pharmacy;
-  editing: boolean;
-  saving: boolean;
   editedNotes?: string;
+  editedOwners?: string;
+  saving: boolean;
 }
 class PharmacyInfoHelper extends React.Component<Props, State> {
   state: State = {
-    editing: false,
     saving: false
   };
 
@@ -46,7 +46,7 @@ class PharmacyInfoHelper extends React.Component<Props, State> {
     if (!this.state.pharmacy) {
       return;
     }
-    this.setState({ editing: true, editedNotes: this.state.pharmacy.notes });
+    this.setState({ editedNotes: this.state.pharmacy.notes });
   };
 
   _onNotesSave = async () => {
@@ -56,14 +56,41 @@ class PharmacyInfoHelper extends React.Component<Props, State> {
     this.setState({ saving: true });
     await setPharmacyDetails(this.props.name, {
       ...this.state.pharmacy,
-      notes: this.state.editedNotes
+      notes: this.state.editedNotes || ""
     });
-    this.setState({ editing: false, saving: false });
+    this.setState({ editedNotes: undefined, saving: false });
   };
 
   _onNotesChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     this.setState({
       editedNotes: event.target.value
+    });
+  };
+
+  _onOwnersEdit = () => {
+    if (!this.state.pharmacy) {
+      return;
+    }
+    this.setState({ editedOwners: this.state.pharmacy.owners.join(", ") });
+  };
+
+  _onOwnersSave = async () => {
+    if (!this.state.pharmacy) {
+      return;
+    }
+    this.setState({ saving: true });
+    await setPharmacyDetails(this.props.name, {
+      ...this.state.pharmacy,
+      owners: (this.state.editedOwners || "")
+        .split(",")
+        .map(owner => owner.trim())
+    });
+    this.setState({ editedOwners: undefined, saving: false });
+  };
+
+  _onOwnersChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({
+      editedOwners: event.target.value
     });
   };
 
@@ -77,31 +104,67 @@ class PharmacyInfoHelper extends React.Component<Props, State> {
             value: this.props.name
           }}
         />
-        {this.state.pharmacy &&
-          (this.state.editing ? (
-            <div className="pharmacy_detail">
-              <div>Notes:</div>
-              <textarea
-                readOnly={this.state.saving}
-                onChange={this._onNotesChange}
-              >
-                {this.state.pharmacy.notes}
-              </textarea>
+        {this.state.pharmacy && (
+          <div className="pharmacy_detail">
+            {this.state.editedNotes !== undefined ? (
               <div>
+                <div>Notes:</div>
+                <textarea
+                  readOnly={this.state.saving}
+                  onChange={this._onNotesChange}
+                  defaultValue={this.state.editedNotes}
+                />
+                <div>
+                  <button
+                    onClick={this._onNotesSave}
+                    disabled={this.state.saving}
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <div>
+                  {`Notes: ${this.state.pharmacy.notes} `}
+                  <button onClick={this._onNotesEdit}>
+                    {this.state.pharmacy.notes.length > 0
+                      ? "Edit"
+                      : "Add Notes"}
+                  </button>
+                </div>
+              </div>
+            )}
+            {this.state.editedOwners !== undefined ? (
+              <div>
+                {"Owners: "}
+                <input
+                  readOnly={this.state.saving}
+                  onChange={this._onOwnersChange}
+                  defaultValue={this.state.editedOwners}
+                />
                 <button
-                  onClick={this._onNotesSave}
+                  onClick={this._onOwnersSave}
                   disabled={this.state.saving}
                 >
                   Save
                 </button>
+                <span className="pharmacy_helptext">
+                  {" (Enter email addresses of owners, separated by commas)"}
+                </span>
               </div>
-            </div>
-          ) : (
-            <div className="pharmacy_detail">
-              {`Notes: ${this.state.pharmacy.notes} `}
-              <button onClick={this._onNotesEdit}>Edit</button>
-            </div>
-          ))}
+            ) : (
+              <div>
+                {`Owners: ${this.state.pharmacy.owners.join(", ")} `}
+                <button onClick={this._onOwnersEdit}>
+                  {this.state.pharmacy.owners.length > 0
+                    ? "Edit"
+                    : "Add Owners"}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/Components/PharmacyInfo.tsx
+++ b/src/Components/PharmacyInfo.tsx
@@ -1,10 +1,10 @@
 import React from "react";
+import Button from "./Button";
 import { Pharmacy } from "../sharedtypes";
 import {
   setPharmacyDetails,
   subscribeToPharmacyDetails
 } from "../store/corestore";
-import Button from "./Button";
 import "./PharmacyInfo.css";
 import TextItem from "./TextItem";
 
@@ -15,8 +15,6 @@ const DEFAULT_PHARMACY: Pharmacy = {
 
 interface Props {
   name: string;
-  onToggleImages: () => void;
-  showImages: boolean;
 }
 
 interface State {
@@ -123,23 +121,25 @@ class PharmacyInfo extends React.Component<Props, State> {
                   defaultValue={this.state.editedNotes}
                 />
                 <div>
-                  <button
+                  <Button
                     onClick={this._onNotesSave}
                     disabled={this.state.saving}
-                  >
-                    Save
-                  </button>
+                    label="Save"
+                  />
                 </div>
               </div>
             ) : (
               <div>
                 <div>
                   {`Notes: ${this.state.pharmacy.notes} `}
-                  <button onClick={this._onNotesEdit}>
-                    {this.state.pharmacy.notes.length > 0
-                      ? "Edit"
-                      : "Add Notes"}
-                  </button>
+                  <Button
+                    onClick={this._onNotesEdit}
+                    label={
+                      this.state.pharmacy.notes.length > 0
+                        ? "Edit"
+                        : "Add Notes"
+                    }
+                  />
                 </div>
               </div>
             )}
@@ -151,12 +151,11 @@ class PharmacyInfo extends React.Component<Props, State> {
                   onChange={this._onOwnersChange}
                   defaultValue={this.state.editedOwners}
                 />
-                <button
+                <Button
                   onClick={this._onOwnersSave}
                   disabled={this.state.saving}
-                >
-                  Save
-                </button>
+                  label="Save"
+                />
                 <span className="pharmacy_helptext">
                   {" (Enter email addresses of owners, separated by commas)"}
                 </span>
@@ -164,19 +163,17 @@ class PharmacyInfo extends React.Component<Props, State> {
             ) : (
               <div>
                 {`Owners: ${this.state.pharmacy.owners.join(", ")} `}
-                <button onClick={this._onOwnersEdit}>
-                  {this.state.pharmacy.owners.length > 0
-                    ? "Edit"
-                    : "Add Owners"}
-                </button>
+                <Button
+                  onClick={this._onOwnersEdit}
+                  label={
+                    this.state.pharmacy.owners.length > 0
+                      ? "Edit"
+                      : "Add Owners"
+                  }
+                />
               </div>
             )}
-            <div className="pharmacy_toggle_image_container">
-              <Button
-                onClick={this.props.onToggleImages}
-                label={!!this.props.showImages ? "Hide Images" : "Show Images"}
-              />
-            </div>
+            {this.props.children}
           </div>
         )}
       </div>

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -157,7 +157,7 @@ export class AuditorDetails extends React.Component<
           <input
             type="text"
             onChange={this._handleSearchTermDetailsChange}
-            placeholder="Filter Details"
+            placeholder="Filter Claims"
           />
         </div>
         {samples.map(this._renderClaimEntryDetails)}

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -160,11 +160,14 @@ export class AuditorDetails extends React.Component<
         className="mainview_details"
         label="DETAILS"
       >
-        <PharmacyInfo
-          showImages={showImages}
-          onToggleImages={this._toggleImages}
-          name={task.site.name}
-        />
+        <PharmacyInfo name={task.site.name}>
+          <div className="pharmacy_toggle_image_container">
+            <Button
+              onClick={this._toggleImages}
+              label={!!showImages ? "Hide Images" : "Show Images"}
+            />
+          </div>
+        </PharmacyInfo>
         <div className="mainview_spaced_row">
           <input
             type="text"

--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -41,7 +41,6 @@
 .mainview_search_container {
   padding: 7px;
   background-color: #888888;
-  height: 110px;
 }
 
 .mainview_clear_search_button {

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -122,6 +122,7 @@ class MainView extends React.Component<Props, State> {
                 detailsComponent={DetailsComponents[tabConfig.detailsComponent]}
                 listLabel={tabConfig.listLabel}
                 actions={tabConfig.actions}
+                filterByOwners={tabConfig.filterByOwners || false}
                 registerForTabSelectCallback={
                   this._registerForTabSelectCallback
                 }

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "react-tabs/style/react-tabs.css";
+import Button from "../Components/Button";
 import ImageRow from "../Components/ImageRow";
 import LabelWrapper from "../Components/LabelWrapper";
 import PharmacyInfo from "../Components/PharmacyInfo";
@@ -89,11 +90,14 @@ export class OperatorDetails extends React.Component<
   render() {
     return (
       <LabelWrapper className="mainview_details" label="DETAILS">
-        <PharmacyInfo
-          showImages={this.state.showImages}
-          onToggleImages={this._toggleImages}
-          name={this.props.task.site.name}
-        />
+        <PharmacyInfo name={this.props.task.site.name}>
+          <div className="pharmacy_toggle_image_container">
+            <Button
+              onClick={this._toggleImages}
+              label={!!this.state.showImages ? "Hide Images" : "Show Images"}
+            />
+          </div>
+        </PharmacyInfo>
         {this.props.task.entries.map(this._renderClaimEntryDetails)}
         {this.props.notesux}
         {this.props.children}

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import "react-tabs/style/react-tabs.css";
 import ImageRow from "../Components/ImageRow";
 import LabelWrapper from "../Components/LabelWrapper";
+import { PharmacyInfo } from "../Components/PharmacyInfo";
 import TextItem from "../Components/TextItem";
 import { DetailsComponentProps } from "./TaskPanel";
 import { ClaimEntry } from "../sharedtypes";
@@ -67,13 +68,7 @@ export class OperatorDetails extends React.Component<DetailsComponentProps> {
   render() {
     return (
       <LabelWrapper className="mainview_details" label="DETAILS">
-        <TextItem
-          data={{
-            displayKey: "Pharmacy",
-            searchKey: "name",
-            value: this.props.task.site.name
-          }}
-        />
+        <PharmacyInfo name={this.props.task.site.name} />
         {this.props.task.entries.map(this._renderClaimEntryDetails)}
         {this.props.notesux}
         {this.props.children}

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -3,7 +3,7 @@ import "react-tabs/style/react-tabs.css";
 import Button from "../Components/Button";
 import DataTable from "../Components/DataTable";
 import LabelWrapper from "../Components/LabelWrapper";
-import { PharmacyInfo } from "../Components/PharmacyInfo";
+import PharmacyInfo from "../Components/PharmacyInfo";
 import TextItem from "../Components/TextItem";
 import { ClaimEntry, Task, TaskState } from "../sharedtypes";
 import {

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -3,6 +3,7 @@ import "react-tabs/style/react-tabs.css";
 import Button from "../Components/Button";
 import DataTable from "../Components/DataTable";
 import LabelWrapper from "../Components/LabelWrapper";
+import { PharmacyInfo } from "../Components/PharmacyInfo";
 import TextItem from "../Components/TextItem";
 import { ClaimEntry, Task, TaskState } from "../sharedtypes";
 import {
@@ -128,13 +129,7 @@ class ConfigurablePayorDetails extends React.Component<
 
     return (
       <LabelWrapper className="mainview_details" label="DETAILS">
-        <TextItem
-          data={{
-            displayKey: "Pharmacy",
-            searchKey: "name",
-            value: task.site.name
-          }}
-        />
+        <PharmacyInfo name={task.site.name} />
         {!!task.site.phone && (
           <TextItem
             data={{

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -102,8 +102,8 @@ export type User = {
 };
 
 export type Pharmacy = {
-  notes?: string;
-  opsOwners: string[];
+  notes: string;
+  owners: string[];
 };
 
 // This is used to log isuses that the Admin needs to see

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -21,6 +21,7 @@ export interface TaskConfig extends TabConfig {
   taskListComponent: string;
   detailsComponent: string;
   listLabel: string;
+  filterByOwners?: boolean;
   actions: { [key: string]: ActionConfig };
 }
 
@@ -85,6 +86,7 @@ export const defaultConfig: AppConfig = {
       listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.OPERATOR],
       baseUrl: "/operator",
+      filterByOwners: true,
       actions: {
         decline: {
           label: "Reject",

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -84,6 +84,10 @@ export async function changeTaskState(
   ]);
 }
 
+export function getUserEmail(): string {
+  return firebase.auth().currentUser!.email!;
+}
+
 export function getBestUserName(): string {
   return (
     firebase.auth().currentUser!.displayName ||
@@ -275,6 +279,16 @@ export function subscribeToPharmacyDetails(
     .onSnapshot(snapshot => {
       callback(snapshot.data() as Pharmacy);
     });
+}
+
+export async function getPharmacyDetails(
+  pharmacyId: string
+): Promise<Pharmacy> {
+  return (await firebase
+    .firestore()
+    .collection(PHARMACY_COLLECTION)
+    .doc(pharmacyId)
+    .get()).data() as Pharmacy;
 }
 
 export async function setPharmacyDetails(


### PR DESCRIPTION
In the "secondary followup" tab, only show ops team members tasks for pharmacies that they own.

Note: This doesn't apply to primary review. We want to show tasks for unowned pharmacies to every member of the team so that they don't fall through the cracks. Reconciling that with a single list of owners gets tricky, so I'm not going to implement that for now. Afkera said they probably won't need this feature in primary review for a while anyway.