### PR TITLE
Extra charting within expandable divs + limited tooltip size

### DIFF
--- a/src/Components/ExpandableDiv.css
+++ b/src/Components/ExpandableDiv.css
@@ -1,0 +1,7 @@
+.expandableDiv_container {
+  cursor: pointer;
+}
+
+.expandableDiv_label {
+  font-weight: bold;
+}

--- a/src/Components/ExpandableDiv.tsx
+++ b/src/Components/ExpandableDiv.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import "./ExpandableDiv.css";
+
+interface Props {
+  children: JSX.Element[] | JSX.Element;
+  defaultExpanded?: boolean;
+  label?: string;
+  onExpand?: () => void;
+}
+
+const ExpandableDiv = (props: Props) => {
+  const [expanded, setExpanded] = useState(props.defaultExpanded || false);
+
+  if (!!props.onExpand && expanded) {
+    props.onExpand();
+  }
+
+  return (
+    <div
+      onClick={() => setExpanded(!expanded)}
+      className="expandableDiv_container"
+    >
+      {
+        <span className="expandableDiv_label">{`${
+          !expanded ? "▶" : "▼"
+        } ${props.label || ""}`}</span>
+      }
+      {!!expanded && props.children}
+    </div>
+  );
+};
+
+export default ExpandableDiv;

--- a/src/Components/PharmacyInfo.tsx
+++ b/src/Components/PharmacyInfo.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import { TaskTotal } from "../Screens/AuditorPanel";
 import { Pharmacy, Site } from "../sharedtypes";
 import {
@@ -7,6 +7,7 @@ import {
 } from "../store/corestore";
 import Button from "./Button";
 import DataTable from "./DataTable";
+import ExpandableDiv from "./ExpandableDiv";
 import "./PharmacyInfo.css";
 import TextItem from "./TextItem";
 import { ToolTipIcon } from "./ToolTipIcon";
@@ -213,11 +214,8 @@ class PharmacyInfo extends React.Component<Props, State> {
         </div>
         <div className="pharmacy_half">
           {!!previousClaims && !!showPreviousClaims && (
-            <Fragment>
+            <ExpandableDiv label="Previous Claims by Pharmacy">
               <div className="pharmacy_claims_header">
-                <span className="pharmacy_claims_header_text">
-                  Previous Claims
-                </span>
                 {!!showIncreaseWarning && (
                   <ToolTipIcon
                     label={"⚠"}
@@ -226,7 +224,7 @@ class PharmacyInfo extends React.Component<Props, State> {
                 )}
               </div>
               <DataTable data={previousClaims} />
-            </Fragment>
+            </ExpandableDiv>
           )}
         </div>
       </div>

--- a/src/Components/ToolTipIcon.css
+++ b/src/Components/ToolTipIcon.css
@@ -1,5 +1,7 @@
 .tooltipicon_container {
   position: relative;
+  width: 25px;
+  height: 25px;
 }
 
 .tooltipicon_label {

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -8,6 +8,7 @@ import "react-tabs/style/react-tabs.css";
 import Button from "../Components/Button";
 import CheckBox from "../Components/CheckBox";
 import ClaimNotes from "../Components/ClaimNotes";
+import ExpandableDiv from "../Components/ExpandableDiv";
 import ImageRow from "../Components/ImageRow";
 import LabelWrapper from "../Components/LabelWrapper";
 import PharmacyInfo from "../Components/PharmacyInfo";
@@ -264,15 +265,14 @@ export class AuditorDetails extends React.Component<
         ))}
 
         {patient.history && patient.history.tasks.length > 0 && (
-          <React.Fragment>
-            <div>Previous claims from this patient:</div>
+          <ExpandableDiv label="Previous claims from this patient">
             <ReactTable
               data={patient.history.tasks}
               columns={PATIENT_HISTORY_TABLE_COLUMNS}
               minRows={0}
               showPagination={false}
             />
-          </React.Fragment>
+          </ExpandableDiv>
         )}
       </LabelWrapper>
     );

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -1,7 +1,7 @@
-import React, { Fragment } from "react";
+import React from "react";
 import "react-tabs/style/react-tabs.css";
-import Button from "../Components/Button";
 import DataTable from "../Components/DataTable";
+import ExpandableDiv from "../Components/ExpandableDiv";
 import LabelWrapper from "../Components/LabelWrapper";
 import PharmacyInfo from "../Components/PharmacyInfo";
 import TextItem from "../Components/TextItem";
@@ -30,16 +30,13 @@ interface RemoteProps {
 }
 interface State {
   relatedTasks?: Task[];
-  showPreviousClaims: boolean;
 }
 
 class ConfigurablePayorDetails extends React.Component<
   DetailsComponentProps & RemoteProps,
   State
 > {
-  state: State = {
-    showPreviousClaims: false
-  };
+  state: State = {};
 
   componentDidMount() {
     this.props.registerActionCallback("approve", this._issuePayment);
@@ -83,12 +80,12 @@ class ConfigurablePayorDetails extends React.Component<
   };
 
   _toggleShowPreviousClaims = () => {
-    if (!this.state.relatedTasks && !this.state.showPreviousClaims) {
-      loadPreviousTasks(this.props.task.site.name, this.props.task.id).then(
-        relatedTasks => this.setState({ relatedTasks })
-      );
+    if (!this.state.relatedTasks) {
+      loadPreviousTasks(
+        this.props.task.site.name,
+        this.props.task.id
+      ).then(relatedTasks => this.setState({ relatedTasks }));
     }
-    this.setState({ showPreviousClaims: !this.state.showPreviousClaims });
   };
 
   render() {
@@ -153,24 +150,12 @@ class ConfigurablePayorDetails extends React.Component<
           }}
         />
         <DataTable data={cleanedData} />
-        {rejectedData.length > 0 && (
-          <Fragment>
-            <span>
-              <b>Rejected Claims</b>
-            </span>
-            <DataTable data={rejectedData} />
-          </Fragment>
-        )}
-        <Button
-          label={
-            this.state.showPreviousClaims
-              ? "Hide Previous Claims ▲"
-              : "Show Previous Claims ▼"
-          }
-          onClick={this._toggleShowPreviousClaims}
-        />
-        {this.state.showPreviousClaims &&
-          (relatedTaskRows ? (
+
+        <ExpandableDiv
+          label="Previous Tasks"
+          onExpand={this._toggleShowPreviousClaims}
+        >
+          {relatedTaskRows ? (
             relatedTaskRows.length ? (
               <DataTable data={relatedTaskRows} />
             ) : (
@@ -178,7 +163,8 @@ class ConfigurablePayorDetails extends React.Component<
             )
           ) : (
             <div className="mainview_details_text">Loading...</div>
-          ))}
+          )}
+        </ExpandableDiv>
         {notesux}
         {this.props.children}
       </LabelWrapper>


### PR DESCRIPTION
[FEV-1496](https://auderenow.atlassian.net/browse/FEV-1496)

For the future: Tie data fetch to onExpand function like in the payor panel's previous tasks so we don't fetch data no one wants.

<img width="651" alt="Screen Shot 2019-11-27 at 10 17 14 AM" src="https://user-images.githubusercontent.com/15152013/69750132-df2a8780-1100-11ea-8d6e-ac2090d69829.png">

<img width="584" alt="Screen Shot 2019-11-27 at 10 17 00 AM" src="https://user-images.githubusercontent.com/15152013/69750139-e5b8ff00-1100-11ea-94ec-7d9f7e194088.png">
