### PR TITLE
Fix owners filtering

### DIFF
--- a/src/Components/PharmacyInfo.tsx
+++ b/src/Components/PharmacyInfo.tsx
@@ -125,6 +125,7 @@ class PharmacyInfo extends React.Component<Props, State> {
       owners: (this.state.editedOwners || "")
         .split(",")
         .map(owner => owner.trim())
+        .filter(owner => owner)
     });
     this.setState({ editedOwners: undefined, saving: false });
   };

--- a/src/Components/TaskList.tsx
+++ b/src/Components/TaskList.tsx
@@ -108,7 +108,7 @@ class TaskList extends React.Component<Props, State> {
           return (
             <div
               className={activeClass}
-              key={index}
+              key={task.id}
               data-tip={activeDataTip}
               data-name={index}
               onClick={this._onItemPressed}


### PR DESCRIPTION
2 fixes:
* Don't save an owner that's just an empty string if you clear the owners textbox
* Load pharmacy info before computing filtered tasks, because otherwise you won't know which pharmacies have other owners