### PR TITLE
Group tasks by pharmacy in auditor/payor tabs

### DIFF
--- a/src/Components/ClaimNotes.tsx
+++ b/src/Components/ClaimNotes.tsx
@@ -32,6 +32,7 @@ class ClaimNotes extends React.Component<Props, State> {
   _onSave = async () => {
     const { notes } = this.state;
     const { claimIndex, task } = this.props;
+    delete (task as any).foundCount;
     await setClaimNotes(task, claimIndex, notes);
     this.setState({ editing: false });
   };

--- a/src/Components/ListItem.tsx
+++ b/src/Components/ListItem.tsx
@@ -4,24 +4,31 @@ import { formatCurrency } from "../store/corestore";
 import "./ListItem.css";
 
 export class ListItem extends React.Component<{
-  task: Task;
+  tasks: Task[];
   isSelected: boolean;
 }> {
   render() {
-    const { task, isSelected } = this.props;
+    const { tasks, isSelected } = this.props;
     const previewName = "listitem" + (isSelected ? " selected" : "");
-    const claimAmounts = task.entries.map(entry => {
-      return !entry.rejected ? entry.claimedCost : 0;
-    });
+    const claimAmounts = tasks
+      .map(task =>
+        task.entries.map(entry => {
+          return !entry.rejected ? entry.claimedCost : 0;
+        })
+      )
+      .flat();
     const claimsTotal = claimAmounts.reduce(
       (sum, claimedCost) => sum + claimedCost
     );
+    const claimCount = tasks
+      .map(task => task.entries.length)
+      .reduce((a, b) => a + b, 0);
     return (
       <div className={previewName}>
         <div className="listitem_header">
-          <span>{task.site.name}</span>
+          <span>{tasks[0].site.name}</span>
           <span>
-            {task.entries.length} Claim{task.entries.length !== 1 ? "s" : ""}
+            {claimCount} Claim{claimCount !== 1 ? "s" : ""}
           </span>
         </div>
         <div>{"Total Reimbursement: " + formatCurrency(claimsTotal)}</div>

--- a/src/Components/TaskList.tsx
+++ b/src/Components/TaskList.tsx
@@ -13,8 +13,8 @@ import "./TaskList.css";
 const MAX_ACTIVE_MSEC = 5 * 60 * 1000; // 5 mins is considered "active"
 
 type Props = {
-  tasks: Task[];
-  renderItem: (task: Task, isSelected: boolean) => JSX.Element;
+  tasks: Task[][];
+  renderItem: (tasks: Task[], isSelected: boolean) => JSX.Element;
   className?: string;
   onSelect?: (index: number) => boolean;
   selectedItem?: number;
@@ -73,18 +73,18 @@ class TaskList extends React.Component<Props, State> {
 
     if (okToSelect) {
       // Let this drift by without await because nothing after it depends on it
-      logActiveTaskView(this.props.tasks[index].id);
+      logActiveTaskView(this.props.tasks[index][0].id);
 
       this.setState({ selectedIndex: index });
     }
   };
 
-  _getActiveViewers(task: Task) {
+  _getActiveViewers(tasks: Task[]) {
     const now = Date.now();
     const activeViewers = this.state.activeTasks
       .filter(
         t =>
-          t.id === task.id &&
+          tasks.some(task => t.id === task.id) &&
           now - dateFromServerTimestamp(t.since).getTime() <= MAX_ACTIVE_MSEC &&
           t.name !== getBestUserName()
       )
@@ -108,7 +108,7 @@ class TaskList extends React.Component<Props, State> {
           return (
             <div
               className={activeClass}
-              key={task.id}
+              key={task[0].id}
               data-tip={activeDataTip}
               data-name={index}
               onClick={this._onItemPressed}

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -31,12 +31,7 @@ const MIN_SAMPLES = 1;
 const PATIENT_HISTORY_TABLE_COLUMNS = [
   { Header: "ID", accessor: "taskId", minWidth: 90 },
   { Header: "DATE", accessor: "date", minWidth: 70 },
-  {
-    Header: "TOTAL AMOUNT",
-    id: "totalAmount",
-    accessor: (row: any) => formatCurrency(row.totalAmount),
-    minWidth: 60
-  },
+  { Header: "TOTAL AMOUNT", accessor: "totalAmount", minWidth: 60 },
   { Header: "NUMBER OF CLAIMS", accessor: "claimCount", minWidth: 70 }
 ];
 
@@ -199,7 +194,7 @@ export class AuditorDetails extends React.Component<
   _toggleRejectClaim = async (event: ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked;
     const claimKey = event.currentTarget.getAttribute("data-value");
-    const [taskIndex, claimIndex] = (claimKey || "").split(".").map(parseInt);
+    const { taskIndex, claimIndex } = JSON.parse(claimKey || "");
 
     if (!claimIndex) {
       return;
@@ -268,7 +263,10 @@ export class AuditorDetails extends React.Component<
                     claim.rejected === undefined ? false : claim.rejected
                   }
                   label={"Rejected"}
-                  value={(claim as any).originalIndex}
+                  value={JSON.stringify({
+                    claimIndex: (claim as any).originalIndex,
+                    taskIndex
+                  })}
                   onCheckBoxSelect={this._toggleRejectClaim}
                   disabled={disabledCheckbox}
                   key={index}

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -33,7 +33,7 @@ const PanelComponents: {
 };
 
 const ItemComponents: {
-  [key: string]: React.ComponentType<{ task: Task; isSelected: boolean }>;
+  [key: string]: React.ComponentType<{ tasks: Task[]; isSelected: boolean }>;
 } = {
   default: ListItem
 };
@@ -136,6 +136,7 @@ class MainView extends React.Component<Props, State> {
           } else {
             panelElement = (
               <TaskPanel
+                config={tabConfig}
                 initialSelectedTaskID={this.props.selectedTaskID}
                 taskState={tabConfig.taskState}
                 itemComponent={ItemComponents[tabConfig.taskListComponent]}

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -33,7 +33,7 @@ class ConfigurableOperatorDetails extends React.Component<
   }
 
   _onSave = async () => {
-    return { success: true, task: this.props.task };
+    return { success: true, tasks: this.props.tasks };
   };
 
   _extractImages = (claim: ClaimEntry) => {
@@ -106,7 +106,7 @@ class ConfigurableOperatorDetails extends React.Component<
   render() {
     return (
       <LabelWrapper className="mainview_details">
-        <PharmacyInfo site={this.props.task.site}>
+        <PharmacyInfo site={this.props.tasks[0].site}>
           <div className="pharmacy_toggle_image_container">
             <Button
               className={"pharmacy_button"}
@@ -115,9 +115,11 @@ class ConfigurableOperatorDetails extends React.Component<
             />
           </div>
         </PharmacyInfo>
-        {this.props.task.entries.map((entry, index) => {
-          return this._renderClaimEntryDetails(entry, index);
-        })}
+        {this.props.tasks.map(task =>
+          task.entries.map((entry, index) => {
+            return this._renderClaimEntryDetails(entry, index);
+          })
+        )}
         <div className="mainview_instructions_header">Instructions:</div>
         <ReactMarkdown source={this.props.instructions} />
         {this.props.notesux}

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -29,6 +29,7 @@ export interface TaskConfig extends TabConfig {
   actions: { [key: string]: ActionConfig };
   hideImagesDefault?: boolean;
   showPreviousClaims?: boolean;
+  groupTasksByPharmacy?: boolean;
 }
 
 export interface AppConfig {
@@ -51,6 +52,7 @@ export const defaultConfig: AppConfig = {
       roles: [UserRole.AUDITOR],
       baseUrl: "auditor",
       showPreviousClaims: true,
+      groupTasksByPharmacy: true,
       actions: {
         decline: {
           label: "DECLINE",
@@ -78,6 +80,7 @@ export const defaultConfig: AppConfig = {
       listLabel: "ITEMS TO REVIEW",
       roles: [UserRole.PAYOR],
       baseUrl: "payor",
+      groupTasksByPharmacy: true,
       actions: {
         decline: {
           label: "DECLINE PAYMENT",

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -159,19 +159,17 @@ export async function loadTasks(taskState: TaskState): Promise<Task[]> {
 
 export async function loadPreviousTasks(
   siteName: string,
-  currentId: string
+  currentIds: string[]
 ): Promise<Task[]> {
   const states = Object.values(TaskState);
-  return (
-    await firebase
-      .firestore()
-      .collection(TASKS_COLLECTION)
-      .where("site.name", "==", siteName)
-      .get()
-  ).docs
+  return (await firebase
+    .firestore()
+    .collection(TASKS_COLLECTION)
+    .where("site.name", "==", siteName)
+    .get()).docs
     .map(doc => doc.data() as Task)
     .sort((t1, t2) => states.indexOf(t1.state) - states.indexOf(t2.state))
-    .filter(t => t.id !== currentId);
+    .filter(t => !currentIds.includes(t.id));
 }
 
 export async function setRoles(
@@ -337,13 +335,11 @@ export function subscribeToPharmacyDetails(
 export async function getPharmacyDetails(
   pharmacyId: string
 ): Promise<Pharmacy> {
-  return (
-    await firebase
-      .firestore()
-      .collection(PHARMACY_COLLECTION)
-      .doc(pharmacyId)
-      .get()
-  ).data() as Pharmacy;
+  return (await firebase
+    .firestore()
+    .collection(PHARMACY_COLLECTION)
+    .doc(pharmacyId)
+    .get()).data() as Pharmacy;
 }
 
 export async function setPharmacyDetails(
@@ -375,25 +371,21 @@ async function getAllDocsIn<T>(
     return [];
   }
 
-  return (
-    await Promise.all(
-      new Array(Math.ceil(attributeValues.length / 10)).fill(0).map(
-        async (_, index) =>
-          (
-            await firebase
-              .firestore()
-              .collection(collection)
-              .where(
-                attribute,
-                //@ts-ignore
-                "in",
-                attributeValues.slice(index * 10, (index + 1) * 10)
-              )
-              .get()
-          ).docs.map((doc: any) => doc.data()) as T[]
-      )
+  return (await Promise.all(
+    new Array(Math.ceil(attributeValues.length / 10)).fill(0).map(
+      async (_, index) =>
+        (await firebase
+          .firestore()
+          .collection(collection)
+          .where(
+            attribute,
+            //@ts-ignore
+            "in",
+            attributeValues.slice(index * 10, (index + 1) * 10)
+          )
+          .get()).docs.map((doc: any) => doc.data()) as T[]
     )
-  ).reduce((a, b) => a.concat(b), []);
+  )).flat();
 }
 
 export async function getPatientHistories(patientIds: string[]) {
@@ -458,13 +450,11 @@ export function saveNotes(categoryName: string, notes: string[]) {
 }
 
 export async function getNotes(categoryName: string): Promise<string[]> {
-  const data = (
-    await firebase
-      .firestore()
-      .collection(CANNED_NOTES_COLLECTION)
-      .doc(categoryName)
-      .get()
-  ).data();
+  const data = (await firebase
+    .firestore()
+    .collection(CANNED_NOTES_COLLECTION)
+    .doc(categoryName)
+    .get()).data();
   return data ? data.notes : [];
 }
 


### PR DESCRIPTION
This is a little weird, but I'm now passing an array of tasks to every task list item and task details component in order to support grouping by pharmacy. On tabs that don't group tasks by pharmacy (completed/rejected/secondary followup), the array is always of length one. For the auditor and payor tabs, the array contains all of the tasks for a given pharmacy currently in that task state.