### PR TITLE
Remove foundCount before saving task

### DIFF
--- a/src/Components/ClaimNotes.tsx
+++ b/src/Components/ClaimNotes.tsx
@@ -32,7 +32,6 @@ class ClaimNotes extends React.Component<Props, State> {
   _onSave = async () => {
     const { notes } = this.state;
     const { claimIndex, task } = this.props;
-    delete (task as any).foundCount;
     await setClaimNotes(task, claimIndex, notes);
     this.setState({ editing: false });
   };

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -196,10 +196,6 @@ export class AuditorDetails extends React.Component<
     const claimKey = event.currentTarget.getAttribute("data-value");
     const { taskIndex, claimIndex } = JSON.parse(claimKey || "");
 
-    if (!claimIndex) {
-      return;
-    }
-
     await setRejectedClaim(this.props.tasks[taskIndex], claimIndex, checked);
   };
 

--- a/src/store/corestore.ts
+++ b/src/store/corestore.ts
@@ -77,11 +77,7 @@ export async function changeTaskState(
   };
   removeEmptyFieldsInPlace(updatedTask);
   return Promise.all([
-    firebase
-      .firestore()
-      .collection(TASKS_COLLECTION)
-      .doc(task.id)
-      .set(updatedTask),
+    saveTask(updatedTask, task.id),
     firebase
       .firestore()
       .collection(TASK_CHANGE_COLLECTION)
@@ -478,11 +474,7 @@ export async function setClaimNotes(
   notes: string
 ) {
   task.entries[claimIndex].notes = notes;
-  return await firebase
-    .firestore()
-    .collection(TASKS_COLLECTION)
-    .doc(task.id)
-    .set(task);
+  return await saveTask(task, task.id);
 }
 
 export async function setRejectedClaim(
@@ -492,9 +484,14 @@ export async function setRejectedClaim(
 ) {
   task.entries[claimIndex].rejected = rejected;
 
-  return await firebase
+  return await saveTask(task, task.id);
+}
+
+function saveTask(task: Task, id: string) {
+  const { foundCount, ...cleanedTask } = task as any;
+  return firebase
     .firestore()
     .collection(TASKS_COLLECTION)
-    .doc(task.id)
-    .set(task);
+    .doc(id)
+    .set(cleanedTask);
 }


### PR DESCRIPTION
`task.foundCount` is sometimes `undefined`, but firestore doesn't allow `undefined` values in documents. Clean them out before saving.