### PR TITLE
Better payment details and audit log messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-tooltip": "^3.9.3",
     "firebase": "^6.6.1",
     "json-2-csv": "^3.5.7",
+    "memoize-one": "^5.1.1",
     "react": "^16.9.0",
     "react-dates": "^21.2.1",
     "react-dom": "^16.9.0",

--- a/src/Components/NotesAudit.css
+++ b/src/Components/NotesAudit.css
@@ -2,3 +2,9 @@
   margin: 10px;
   overflow-wrap: break-word;
 }
+
+.notesaudit_tasklink {
+  text-decoration: underline;
+  font-weight: bold;
+  cursor: pointer;
+}

--- a/src/Components/NotesAudit.tsx
+++ b/src/Components/NotesAudit.tsx
@@ -28,7 +28,7 @@ const CHANGE_MESSAGES: {
   },
   [TaskState.AUDIT]: {
     [TaskState.AUDIT]: "added a note",
-    [TaskState.FOLLOWUP]: "sent for followup",
+    [TaskState.FOLLOWUP]: "sent for secondary followup",
     [TaskState.PAY]: "approved for payment"
   },
   [TaskState.FOLLOWUP]: {
@@ -38,6 +38,7 @@ const CHANGE_MESSAGES: {
     [TaskState.AUDIT]: "sent back to primary review"
   },
   [TaskState.PAY]: {
+    [TaskState.FOLLOWUP]: "sent back for secondary followup",
     [TaskState.COMPLETED]: (change, by, when, tasks) => {
       if (!change.payment) {
         return `${by} paid ${when}`;

--- a/src/Components/NotesAudit.tsx
+++ b/src/Components/NotesAudit.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { Fragment, useState, useEffect } from "react";
+import { RouteComponentProps, withRouter } from "react-router";
+import { Link } from "react-router-dom";
 import "./NotesAudit.css";
-import { TaskChangeRecord } from "../sharedtypes";
+import { PaymentType, TaskChangeRecord, Task, TaskState } from "../sharedtypes";
+import { formatCurrency, getAllTasks } from "../store/corestore";
 import ReactTooltip from "react-tooltip";
 import moment from "moment";
 
@@ -8,8 +11,111 @@ interface Props {
   change: TaskChangeRecord;
 }
 
+const CHANGE_MESSAGES: {
+  [from: string]: {
+    [to: string]:
+      | React.ReactNode
+      | ((
+          change: TaskChangeRecord,
+          by: string,
+          when: string,
+          tasks: { [taskId: string]: Task }
+        ) => React.ReactNode);
+  };
+} = {
+  [TaskState.CSV]: {
+    [TaskState.AUDIT]: "uploaded for primary review"
+  },
+  [TaskState.AUDIT]: {
+    [TaskState.AUDIT]: "added a note",
+    [TaskState.FOLLOWUP]: "sent for followup",
+    [TaskState.PAY]: "approved for payment"
+  },
+  [TaskState.FOLLOWUP]: {
+    [TaskState.FOLLOWUP]: "added a note",
+    [TaskState.REJECTED]: "rejected",
+    [TaskState.PAY]: "approved for payment",
+    [TaskState.AUDIT]: "sent back to primary review"
+  },
+  [TaskState.PAY]: {
+    [TaskState.COMPLETED]: (change, by, when, tasks) => {
+      if (!change.payment) {
+        return `${by} paid ${when}`;
+      }
+      if (change.payment.paymentType === PaymentType.BUNDLED) {
+        const bundledTask =
+          change.payment.bundledUnderTaskId &&
+          tasks[change.payment.bundledUnderTaskId];
+        return (
+          <Fragment>
+            {by} paid. See:{" "}
+            <TaskLink
+              taskId={change.payment.bundledUnderTaskId!}
+              state="completed"
+            >
+              Week of{" "}
+              {bundledTask
+                ? new Date(bundledTask.createdAt).toLocaleDateString()
+                : change.payment.bundledUnderTaskId!.substring(0, 12)}
+            </TaskLink>
+          </Fragment>
+        );
+      }
+      if (change.payment.paymentType === PaymentType.MANUAL) {
+        return `${by} manually paid ${formatCurrency(
+          change.payment.amount
+        )} ${when}`;
+      } else {
+        return `${by} paid ${formatCurrency(change.payment.amount)} to ${
+          change.payment.recipient!.phoneNumber
+        } ${when}`;
+      }
+    }
+  }
+};
+
+const TaskLink = withRouter(
+  (
+    props: RouteComponentProps & {
+      taskId: string;
+      state: string;
+      children?: React.ReactNode;
+    }
+  ) => {
+    return (
+      <Link
+        to={`/${props.state}/${props.taskId}`}
+        className="notesaudit_tasklink"
+      >
+        {props.children}
+      </Link>
+    );
+  }
+);
+
 const NotesAudit = (props: Props) => {
-  const { timestamp, by, state, fromState, notes } = props.change;
+  const { timestamp, by, notes } = props.change;
+  const [tasks, setTasks] = useState({});
+  const bundledTaskIds =
+    props.change.payment && props.change.payment.bundledTaskIds;
+  const bundledUnderTaskId =
+    props.change.payment && props.change.payment.bundledUnderTaskId;
+  useEffect(() => {
+    (async () => {
+      const otherTaskIds = bundledTaskIds || [];
+      if (bundledUnderTaskId) {
+        otherTaskIds.push(bundledUnderTaskId);
+      }
+      if (!otherTaskIds.length) {
+        return;
+      }
+      const tasksById: { [id: string]: Task } = {};
+      (await getAllTasks(otherTaskIds)).forEach(
+        task => (tasksById[task.id] = task)
+      );
+      setTasks(tasksById);
+    })();
+  }, [bundledTaskIds, bundledUnderTaskId]);
   const notesClause = notes ? (
     <span>
       {": "}
@@ -18,8 +124,12 @@ const NotesAudit = (props: Props) => {
   ) : (
     ""
   );
-  const desc = `moved from ${fromState} to ${state}`;
-  const when = moment(timestamp).fromNow();
+  const desc = getDescription(
+    props.change,
+    by,
+    moment(timestamp).fromNow(),
+    tasks
+  );
   const tip = new Date(timestamp).toLocaleString();
   return (
     <div
@@ -27,11 +137,51 @@ const NotesAudit = (props: Props) => {
       key={`${props.change.timestamp}`}
       data-tip={tip}
     >
-      {`${by} ${desc} ${when}`}
+      {desc}
       {notesClause}
       <ReactTooltip key={tip} />
     </div>
   );
 };
+
+function getDescription(
+  change: TaskChangeRecord,
+  by: string,
+  when: string,
+  otherTasks: { [taskId: string]: Task }
+) {
+  const { fromState, state: toState } = change;
+  let msg = "";
+  if (CHANGE_MESSAGES[fromState] && CHANGE_MESSAGES[fromState][toState]) {
+    const message = CHANGE_MESSAGES[fromState][toState];
+    if (typeof message === "function") {
+      msg = message(change, by, when, otherTasks);
+    } else {
+      msg = `${by} ${message} ${when}`;
+    }
+  } else {
+    msg = `${by} moved from ${fromState} to ${toState} ${when}`;
+  }
+  if (change.payment && change.payment.bundledTaskIds) {
+    return [
+      msg,
+      <div>This payment also covered:</div>,
+      ...change.payment.bundledTaskIds.map(taskId => {
+        const task = otherTasks[taskId];
+        if (!task) {
+          return null;
+        }
+        return (
+          <div key={taskId}>
+            <TaskLink taskId={taskId} state="completed">
+              Week of {new Date(task.createdAt).toLocaleDateString()}
+            </TaskLink>
+          </div>
+        );
+      })
+    ];
+  }
+  return msg;
+}
 
 export default NotesAudit;

--- a/src/Components/NotesAudit.tsx
+++ b/src/Components/NotesAudit.tsx
@@ -49,7 +49,7 @@ const CHANGE_MESSAGES: {
           tasks[change.payment.bundledUnderTaskId];
         return (
           <Fragment>
-            {by} paid. See:{" "}
+            {by} paid {when}. See:{" "}
             <TaskLink
               taskId={change.payment.bundledUnderTaskId!}
               state="completed"

--- a/src/Components/SearchableTable.tsx
+++ b/src/Components/SearchableTable.tsx
@@ -2,7 +2,7 @@ import { json2csv } from "json-2-csv";
 import moment from "moment";
 import React from "react";
 import { RouteComponentProps, withRouter } from "react-router";
-import ReactTable from "react-table";
+import ReactTable, { Column } from "react-table";
 import "react-table/react-table.css";
 import ClearSearchImg from "../assets/close.png";
 import DownloadCSVImg from "../assets/downloadcsv.png";
@@ -15,7 +15,7 @@ import "./SearchableTable.css";
 import { ToolTipIcon } from "./ToolTipIcon";
 
 type Props = RouteComponentProps & {
-  tableColumns: any[];
+  tableColumns: Column<any>[];
   allData: HistoryRow[];
   downloadPrefix: string;
 };

--- a/src/Screens/AdminPanel.tsx
+++ b/src/Screens/AdminPanel.tsx
@@ -1,7 +1,7 @@
 import moment from "moment";
 import React from "react";
 import ReactMarkdown from "react-markdown";
-import { RowRenderProps } from "react-table";
+import { RowRenderProps, Column } from "react-table";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import ReactTooltip from "react-tooltip";
 import Button from "../Components/Button";
@@ -54,13 +54,13 @@ type State = {
 
 export type HistoryRow = {
   id: string;
-  time: string;
+  time: number;
   description: string;
   notes?: string;
   state?: TaskState;
 };
 
-const HISTORY_TABLE_COLUMNS = [
+const HISTORY_TABLE_COLUMNS: Column<any>[] = [
   {
     Header: "ID",
     accessor: "id",
@@ -71,6 +71,7 @@ const HISTORY_TABLE_COLUMNS = [
   },
   {
     Header: "TIME",
+    id: "timestamp",
     accessor: "time",
     Cell: (props: RowRenderProps) => renderTooltippedTime(props.value),
     minWidth: 60
@@ -188,7 +189,7 @@ class AdminPanel extends React.Component<Props, State> {
     return records.map(r => {
       return {
         id: r.taskID,
-        time: new Date(r.timestamp).toLocaleDateString(),
+        time: r.timestamp,
         description: !!r.fromState
           ? `${r.by} changed task from ${r.fromState} to ${r.state}`
           : `${r.by} ${(r as any).desc}`,
@@ -202,7 +203,7 @@ class AdminPanel extends React.Component<Props, State> {
     return records.map(r => {
       return {
         id: "",
-        time: new Date(r.timestamp).toLocaleDateString(),
+        time: r.timestamp,
         description: r.desc,
         notes: r.notes || ""
       };
@@ -405,9 +406,9 @@ class AdminPanel extends React.Component<Props, State> {
   }
 }
 
-function renderTooltippedTime(timestamp: string) {
+function renderTooltippedTime(timestamp: number) {
   const tip = moment(timestamp).fromNow();
-  const when = timestamp;
+  const when = new Date(timestamp).toLocaleDateString();
 
   return (
     <span data-tip={tip}>

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -120,7 +120,6 @@ class ConfigurablePayorDetails extends React.Component<
   }
 
   _issuePayment = async (): Promise<ActionCallbackResult> => {
-    debugger;
     const { tasks } = this.props;
     const reimburseAmount = _getReimbursementTotal(tasks);
 

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -70,7 +70,6 @@ type State = {
   tasks: Task[];
   changes: TaskChangeRecord[][];
   selectedTaskIndex: number;
-  selectedTaskId?: string;
   initialSelectedTaskID?: string;
   focusedInput: FocusedInputShape | null;
   searchDates: DateRange;
@@ -114,57 +113,29 @@ class TaskPanel extends React.Component<Props, State> {
     this._unsubscribe();
   }
 
-  _getSelectedTaskId() {}
+  _getSelectedTask() {
+    const { selectedTaskId, selectedTaskIndex } = computeSelectedTaskId(
+      this._groupTasks(),
+      this.state.selectedTaskIndex,
+      this.props.initialSelectedTaskID
+    );
+    if (selectedTaskId && this.props.initialSelectedTaskID !== selectedTaskId) {
+      this._pushHistory(selectedTaskId);
+    }
+    setImmediate(() => this.setState({ selectedTaskIndex }));
+    return { selectedTaskIndex, selectedTaskId };
+  }
 
   _onTasksChanged = async (tasks: Task[]) => {
     const changes = await Promise.all(tasks.map(t => getChanges(t.id)));
-    let { notes, selectedTaskIndex, selectedTaskId } = this.state;
+    let { notes, selectedTaskIndex } = this.state;
 
-    if (tasks.length === 0) {
-      selectedTaskIndex = -1;
-      selectedTaskId = undefined;
-      notes = "";
-    } else {
-      if (
-        !!this.props.initialSelectedTaskID &&
-        this.props.initialSelectedTaskID !== this.state.initialSelectedTaskID
-      ) {
-        selectedTaskId = this.props.initialSelectedTaskID;
-        this.setState({
-          initialSelectedTaskID: this.props.initialSelectedTaskID
-        });
-      }
-
-      const groupedTasks = this._groupTasks(tasks);
-      selectedTaskIndex = groupedTasks.findIndex(tasks =>
-        tasks.some(task => task.id === selectedTaskId)
-      );
-      if (selectedTaskIndex === -1) {
-        selectedTaskIndex = 0;
-        selectedTaskId = tasks[0].id;
-        notes = "";
-      } else {
-        if (selectedTaskIndex === -1) {
-          selectedTaskIndex = Math.min(
-            this.state.selectedTaskIndex,
-            groupedTasks.length - 1
-          );
-          selectedTaskId = tasks[selectedTaskIndex].id;
-          notes = "";
-        }
-      }
-    }
-
-    if (selectedTaskId !== this.state.selectedTaskId) {
-      this._pushHistory(selectedTaskId);
-    }
     this.setState(
       {
         allTasks: tasks,
         tasks,
         changes,
         selectedTaskIndex,
-        selectedTaskId,
         notes
       },
       this._updateTasks
@@ -198,7 +169,6 @@ class TaskPanel extends React.Component<Props, State> {
         index === -1 ? undefined : this._groupTasks()[index][0].id;
       this.setState({
         selectedTaskIndex: index,
-        selectedTaskId,
         notes: ""
       });
       this._pushHistory(selectedTaskId);
@@ -299,7 +269,7 @@ class TaskPanel extends React.Component<Props, State> {
   };
 
   _updateTasks = async () => {
-    const { selectedTaskIndex, tasks } = this.state;
+    const { tasks } = this.state;
     const pharmacyNames: { [name: string]: boolean } = {};
     tasks.forEach(task => (pharmacyNames[task.site.name] = true));
     const pharmacies: { [name: string]: Pharmacy } = {};
@@ -317,8 +287,6 @@ class TaskPanel extends React.Component<Props, State> {
         res
       )
     );
-    const selectedId =
-      selectedTaskIndex >= 0 ? tasks[selectedTaskIndex].id : "";
     const filteredTasks = this._computeFilteredTasks(
       this.state.searchTermGlobal,
       this.state.searchDates
@@ -326,23 +294,11 @@ class TaskPanel extends React.Component<Props, State> {
 
     const changes = await Promise.all(filteredTasks.map(t => getChanges(t.id)));
 
-    const selectedIndex = filteredTasks.findIndex(task => {
-      return task.id === selectedId;
+    this.setState({
+      tasks: filteredTasks,
+      notes: "",
+      changes
     });
-
-    this.setState(
-      {
-        tasks: filteredTasks,
-        selectedTaskIndex: selectedIndex,
-        notes: "",
-        changes
-      },
-      () => {
-        if (selectedIndex === -1 && filteredTasks.length > 0) {
-          this._onTaskSelect(0);
-        }
-      }
-    );
   };
 
   _clearSearch = async () => {
@@ -511,7 +467,8 @@ class TaskPanel extends React.Component<Props, State> {
   };
 
   render() {
-    const { searchTermGlobal, selectedTaskIndex, notes } = this.state;
+    const { searchTermGlobal, notes } = this.state;
+    const { selectedTaskIndex } = this._getSelectedTask();
     const actionable = Object.keys(this.props.actions).length > 0;
     const notesux =
       selectedTaskIndex >= 0 ? (
@@ -706,3 +663,29 @@ const groupTasksByPharmacy = memoize((tasks: Task[]) => {
   });
   return Object.values(tasksByPharmacy);
 });
+
+const computeSelectedTaskId = memoize(
+  (
+    groupedTasks: Task[][],
+    selectedTaskIndex: number,
+    selectedTaskId?: string
+  ) => {
+    let newSelectedTaskIndex;
+    if (groupedTasks.length === 0) {
+      newSelectedTaskIndex = -1;
+      selectedTaskId = undefined;
+    } else {
+      newSelectedTaskIndex = groupedTasks.findIndex(tasks =>
+        tasks.some(task => task.id === selectedTaskId)
+      );
+      if (newSelectedTaskIndex === -1) {
+        newSelectedTaskIndex = Math.min(
+          Math.max(0, selectedTaskIndex),
+          groupedTasks.length - 1
+        );
+        selectedTaskId = groupedTasks[newSelectedTaskIndex][0].id;
+      }
+    }
+    return { selectedTaskIndex: newSelectedTaskIndex, selectedTaskId };
+  }
+);

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -194,9 +194,7 @@ class TaskPanel extends React.Component<Props, State> {
     const result = this._okToSwitchAway();
     if (result) {
       const selectedTaskId =
-        index === -1
-          ? undefined
-          : groupTasksByPharmacy(this.state.tasks)[index][0].id;
+        index === -1 ? undefined : this._groupTasks()[index][0].id;
       this.setState({
         selectedTaskIndex: index,
         selectedTaskId,

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -15,6 +15,7 @@ import TaskList from "../Components/TaskList";
 import { SearchContext } from "../Components/TextItem";
 import { ToolTipIcon } from "../Components/ToolTipIcon";
 import {
+  PaymentRecord,
   Pharmacy,
   RemoteConfig,
   Task,
@@ -111,6 +112,8 @@ class TaskPanel extends React.Component<Props, State> {
   componentWillUnmount() {
     this._unsubscribe();
   }
+
+  _getSelectedTaskId() {}
 
   _onTasksChanged = async (tasks: Task[]) => {
     const changes = await Promise.all(tasks.map(t => getChanges(t.id)));
@@ -582,9 +585,10 @@ interface DetailsWrapperState {
   buttonsBusy: { [key: string]: boolean };
 }
 
-interface ActionCallbackResult {
+export interface ActionCallbackResult {
   success: boolean;
   tasks?: Task[];
+  payments?: PaymentRecord[];
 }
 
 class DetailsWrapper extends React.Component<
@@ -614,8 +618,9 @@ class DetailsWrapper extends React.Component<
       }
     }));
     let tasks: Task[] = this.props.tasks;
+    let result: ActionCallbackResult;
     if (this._actionCallbacks[key]) {
-      let result = await this._actionCallbacks[key]();
+      result = await this._actionCallbacks[key]();
       this.setState(state => ({
         buttonsBusy: {
           ...state.buttonsBusy,
@@ -626,11 +631,12 @@ class DetailsWrapper extends React.Component<
     }
 
     await Promise.all(
-      tasks.map(task =>
+      tasks.map((task, index) =>
         changeTaskState(
           task,
           this.props.actions[key].nextTaskState,
-          this.props.notes
+          this.props.notes,
+          result && result.payments ? result.payments[index] : undefined
         )
       )
     );

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -122,7 +122,9 @@ class TaskPanel extends React.Component<Props, State> {
     if (selectedTaskId && this.props.initialSelectedTaskID !== selectedTaskId) {
       this._pushHistory(selectedTaskId);
     }
-    setImmediate(() => this.setState({ selectedTaskIndex }));
+    if (this.state.selectedTaskIndex !== selectedTaskIndex) {
+      this.setState({ selectedTaskIndex });
+    }
     return { selectedTaskIndex, selectedTaskId };
   }
 

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -1,5 +1,6 @@
 import { json2csv } from "json-2-csv";
 import moment, { Moment } from "moment";
+import memoize from "memoize-one";
 import React, { Fragment, ReactNode } from "react";
 import { DateRangePicker, FocusedInputShape } from "react-dates";
 import { RouteComponentProps, withRouter } from "react-router";
@@ -694,7 +695,7 @@ const ConfiguredDetailsWrapper = configuredComponent<
   return { remoteConfig: configProps };
 });
 
-function groupTasksByPharmacy(tasks: Task[]) {
+const groupTasksByPharmacy = memoize((tasks: Task[]) => {
   const tasksByPharmacy: { [pharmacyName: string]: Task[] } = {};
   tasks.forEach(task => {
     if (tasksByPharmacy[task.site.name]) {
@@ -704,4 +705,4 @@ function groupTasksByPharmacy(tasks: Task[]) {
     }
   });
   return Object.values(tasksByPharmacy);
-}
+});

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -134,7 +134,7 @@ class TaskPanel extends React.Component<Props, State> {
         });
       }
 
-      const groupedTasks = groupTasksByPharmacy(tasks);
+      const groupedTasks = this._groupTasks(tasks);
       selectedTaskIndex = groupedTasks.findIndex(tasks =>
         tasks.some(task => task.id === selectedTaskId)
       );
@@ -503,11 +503,11 @@ class TaskPanel extends React.Component<Props, State> {
     this.setState({ notes });
   };
 
-  _groupTasks = () => {
+  _groupTasks = (tasks: Task[] = this.state.tasks) => {
     if (this.props.config.groupTasksByPharmacy) {
-      return groupTasksByPharmacy(this.state.tasks);
+      return groupTasksByPharmacy(tasks);
     } else {
-      return this.state.tasks.map(task => [task]);
+      return tasks.map(task => [task]);
     }
   };
 

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -76,7 +76,22 @@ export type TaskChangeRecord = {
   timestamp: number;
   by: string;
   notes?: string;
+  payment?: PaymentRecord;
 };
+
+export type PaymentRecord = {
+  paymentType: PaymentType;
+  amount: number;
+  bundledUnderTaskId?: string;
+  bundledTaskIds?: string[];
+  recipient?: PaymentRecipient;
+};
+
+export enum PaymentType {
+  MANUAL,
+  AFRICAS_TALKING,
+  BUNDLED
+}
 
 export type Task = {
   id: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7323,6 +7323,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+memoize-one@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+
 memory-fs@^0.4.0, memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"


### PR DESCRIPTION
The translated the audit log messages from things like `Ram Kandasamy moved from CSV to AUDIT 21 days ago` to `Ram Kandasamy uploaded for primary review 21 days ago`, and adds more details when it's a payment, e.g.:
![image](https://user-images.githubusercontent.com/1070243/70765858-e3fe5680-1d10-11ea-98d2-531908cf980c.png)
or
![image](https://user-images.githubusercontent.com/1070243/70765921-15772200-1d11-11ea-97e5-675f2c158b5a.png)
