### PR TITLE
Remove orphaned tooltip

### DIFF
--- a/src/Components/NotesAudit.tsx
+++ b/src/Components/NotesAudit.tsx
@@ -85,7 +85,10 @@ const TaskLink = withRouter(
   ) => {
     return (
       <Link
-        to={`/${props.state}/${props.taskId}`}
+        to={() => {
+          ReactTooltip.hide();
+          return `/${props.state}/${props.taskId}`;
+        }}
         className="notesaudit_tasklink"
       >
         {props.children}


### PR DESCRIPTION
Before:
![tooltip](https://user-images.githubusercontent.com/1070243/72653999-6b5b6d00-3942-11ea-9e6a-40d86b347657.gif)
After:
![tooltip2](https://user-images.githubusercontent.com/1070243/72654014-829a5a80-3942-11ea-812a-1adb93821cb0.gif)
