### PR TITLE
AUD-1837 Better triage options for individual claims

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "json-2-csv": "^3.5.7",
     "memoize-one": "^5.1.1",
     "react": "^16.9.0",
+    "react-confirm-alert": "^2.6.2",
     "react-dates": "^21.2.1",
     "react-dom": "^16.9.0",
     "react-firebaseui": "^4.0.0",

--- a/src/Components/CheckBox.css
+++ b/src/Components/CheckBox.css
@@ -1,9 +1,12 @@
 .checkbox_input {
-  font-size: small;
-  cursor: pointer;
+  margin-left: 2px;
 }
 
 .checkbox_row {
   display: flex;
   align-items: center;
+  cursor: pointer;
+  padding: 4px 0px;
+  margin: 4px 0px;
+  font-size: var(--body-size);
 }

--- a/src/Components/CheckBox.tsx
+++ b/src/Components/CheckBox.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import "./CheckBox.css";
+
+import React from "react";
 
 interface Props {
   onCheckBoxSelect: (value: string, checked: boolean) => void;
@@ -7,6 +8,8 @@ interface Props {
   label: string;
   value: string;
   disabled?: boolean;
+  radio?: boolean;
+  className?: string;
 }
 
 class CheckBox extends React.Component<Props> {
@@ -15,15 +18,18 @@ class CheckBox extends React.Component<Props> {
   };
 
   render() {
-    const { checked, label, value } = this.props;
+    const { checked, label, value, radio, className } = this.props;
     return (
-      <div className="checkbox_row" onClick={this._onCheckBoxSelect}>
+      <div
+        className={`checkbox_row ${className || ""}`}
+        onClick={this._onCheckBoxSelect}
+      >
         <input
           style={{ display: "inline" }}
           data-value={value}
           className="checkbox_input"
-          type="checkbox"
-          name={label}
+          type={radio ? "radio" : "checkbox"}
+          name={label + value}
           readOnly
           checked={checked}
           disabled={this.props.disabled}

--- a/src/Screens/AuditorPanel.css
+++ b/src/Screens/AuditorPanel.css
@@ -1,0 +1,8 @@
+.claim_options_container {
+  display: flex;
+  flex-direction: row;
+}
+
+.claim_option {
+  margin-right: 20px;
+}

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -4,14 +4,15 @@ import "react-tabs/style/react-tabs.css";
 import "./MainView.css";
 import "./AuditorPanel.css";
 
-import { ClaimEntry, Task } from "../sharedtypes";
+import { ClaimAction, DetailsComponentProps } from "./TaskPanel";
+import { ClaimEntry, Task, TaskState } from "../sharedtypes";
+import { DataStoreType, defaultConfig } from "../store/config";
 import { Flag, PatientHistory } from "../transport/baseDatastore";
 import TextItem, { SearchContext } from "../Components/TextItem";
 
 import Button from "../Components/Button";
 import CheckBox from "../Components/CheckBox";
 import ClaimNotes from "../Components/ClaimNotes";
-import { DetailsComponentProps } from "./TaskPanel";
 import DownloadCSVImg from "../assets/downloadcsv.png";
 import ImageRow from "../Components/ImageRow";
 import LabelWrapper from "../Components/LabelWrapper";
@@ -205,6 +206,16 @@ export class AuditorDetails extends React.Component<
     );
   };
 
+  _updateClaimAction = (value: string, checked: boolean) => {
+    const {
+      claimId,
+      claimAction,
+    }: { claimId: string; claimAction: ClaimAction } = JSON.parse(value);
+    this.props.updateSelectedAction(claimId, {
+      action: checked ? claimAction : undefined,
+    });
+  };
+
   _updateFlag = (value: string, checked: boolean) => {
     const {
       claimId,
@@ -264,8 +275,8 @@ export class AuditorDetails extends React.Component<
             />
           </div>
           {patient.currentClaims.map((task, taskIndex) =>
-            task.claims.map((claim, index) => (
-              <React.Fragment key={`${claim.totalCost}_${index}`}>
+            task.claims.map((claim, claimIndex) => (
+              <React.Fragment key={`${index}_${taskIndex}_${claimIndex}`}>
                 <TextItem
                   data={{
                     displayKey: "Date",
@@ -277,19 +288,85 @@ export class AuditorDetails extends React.Component<
                   showImages={showImages}
                   images={this._extractImages(claim)}
                 />
-                <CheckBox
-                  checked={
-                    claim.rejected === undefined ? false : claim.rejected
-                  }
-                  label={"Rejected"}
-                  value={JSON.stringify({
-                    claimIndex: (claim as any).originalIndex,
-                    taskIndex,
-                  })}
-                  onCheckBoxSelect={this._toggleRejectClaim}
-                  disabled={disabledCheckbox}
-                  key={index}
-                />
+                {claim.items.map((item, itemIndex) => (
+                  <React.Fragment key={item.name + itemIndex}>
+                    <TextItem
+                      data={{
+                        displayKey: "Item",
+                        searchKey: "item",
+                        value: item.name,
+                      }}
+                    />
+                    {item.photoUrl && (
+                      <ImageRow
+                        showImages={showImages}
+                        images={[item.photoUrl]}
+                      />
+                    )}
+                  </React.Fragment>
+                ))}
+                {this.props.taskConfig.showFlagForReview && (
+                  <CheckBox
+                    checked={
+                      this.props.selectedActions[claim.claimID] &&
+                      this.props.selectedActions[claim.claimID].flag
+                    }
+                    label={this.props.taskConfig.showFlagForReview}
+                    value={JSON.stringify({ claimId: claim.claimID })}
+                    onCheckBoxSelect={this._updateFlag}
+                    disabled={disabledCheckbox}
+                  />
+                )}
+                <div className="claim_options_container">
+                  <CheckBox
+                    checked={
+                      this.props.selectedActions[claim.claimID] &&
+                      this.props.selectedActions[claim.claimID].action ===
+                        ClaimAction.APPROVE
+                    }
+                    label={"Approve"}
+                    value={JSON.stringify({
+                      claimAction: ClaimAction.APPROVE,
+                      claimId: claim.claimID,
+                    })}
+                    onCheckBoxSelect={this._updateClaimAction}
+                    disabled={disabledCheckbox}
+                    radio={true}
+                    className="claim_option"
+                  />
+                  <CheckBox
+                    checked={
+                      this.props.selectedActions[claim.claimID] &&
+                      this.props.selectedActions[claim.claimID].action ===
+                        ClaimAction.HOLD
+                    }
+                    label={"Hold"}
+                    value={JSON.stringify({
+                      claimAction: ClaimAction.HOLD,
+                      claimId: claim.claimID,
+                    })}
+                    onCheckBoxSelect={this._updateClaimAction}
+                    disabled={disabledCheckbox}
+                    radio={true}
+                    className="claim_option"
+                  />
+                  <CheckBox
+                    checked={
+                      this.props.selectedActions[claim.claimID] &&
+                      this.props.selectedActions[claim.claimID].action ===
+                        ClaimAction.REJECT
+                    }
+                    label={"Reject"}
+                    value={JSON.stringify({
+                      claimAction: ClaimAction.REJECT,
+                      claimId: claim.claimID,
+                    })}
+                    onCheckBoxSelect={this._updateClaimAction}
+                    disabled={disabledCheckbox}
+                    radio={true}
+                    className="claim_option"
+                  />
+                </div>
                 <ClaimNotes
                   claimIndex={(claim as any).originalIndex}
                   task={this.props.tasks[task.taskIndex]}


### PR DESCRIPTION
Fixes: https://auderenow.atlassian.net/browse/AUD-1837
Allow reviewers to select approve/hold/reject for individual claims, or flag them for patient review (i.e. tell the next reviewer for this claim to call that patient and verify that the transaction really happened). For the first two review stages, reviewers will have to approve at least 20% of the claims before bulk-approving the rest of the claims for the facility using the big "approve" button at the bottom of the page. Individual claims that were rejected get sent to rejection review instead, and held claims stay in their current state.

![image](https://user-images.githubusercontent.com/1070243/96111363-f5b30c00-0e95-11eb-8184-773e23682b20.png)

They wanted to make sure people didn't accidentally bulk-decline claims, so we show this confirmation dialog:
![image](https://user-images.githubusercontent.com/1070243/96113069-71ae5380-0e98-11eb-9df6-8aef789544ec.png)

The individual claim selections are saved to local storage in case you refresh the page while working on a big set of claims.

**Reviewer should merge**
* No
