### PR TITLE
AUD-1736 No longer group claims by patient

### DIFF
--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -518,37 +518,14 @@ export class AuditorDetails extends React.Component<
 }
 
 function getPatients(tasks: Task[]): PatientInfo[] {
-  const entriesByPatient: { [id: string]: PatientInfo } = {};
-  tasks.forEach((task, taskIndex) =>
-    task.entries.forEach((entry, index) => {
-      const id = entry.patientID || `Patient ${index}`;
-      (entry as any).originalIndex = index;
-      if (entriesByPatient[id]) {
-        const taskGroup = entriesByPatient[id].currentClaims.find(
-          entry => entry.taskIndex === taskIndex
-        );
-        if (taskGroup) {
-          taskGroup.claims.push(entry);
-        } else {
-          entriesByPatient[id].currentClaims.push({
-            taskIndex,
-            claims: [entry],
-          });
-        }
-      } else {
-        entriesByPatient[id] = {
-          patientId: id,
-          currentClaims: [
-            {
-              taskIndex,
-              claims: [entry],
-            },
-          ],
-        };
-      }
-    })
-  );
-  return Object.values(entriesByPatient).sort(
-    (a, b) => b.currentClaims.length - a.currentClaims.length
-  );
+  return tasks.map((task, index) => ({
+    patientId: task.entries[0].patientID || "",
+    currentClaims: [
+      {
+        taskIndex: index,
+        claims: task.entries,
+      },
+    ],
+  }));
+}
 }


### PR DESCRIPTION
Fixes: https://auderenow.atlassian.net/browse/AUD-1736

As I mentioned in a previous PR, we no longer group claims by patient, but instead by visit. This removes the patient grouping logic. Now if a patient visits a pharmacy multiple times in a week, there will just be multiple `PatientInfo` entries for that patient.

**Reviewer should merge**
* No
<!-- Delete one of the above -->
