### PR TITLE
AUD-1736 Remove old reviewed flag handling

### DIFF
--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -26,8 +26,7 @@ import { formatCurrency } from "../util/currency";
 import { json2csv } from "json-2-csv";
 import moment from "moment";
 
-const MIN_SAMPLE_FRACTION = 0.2;
-const MIN_SAMPLES = 1;
+const SAMPLES_PER_PAGE = 25;
 const PATIENT_HISTORY_TABLE_COLUMNS = [
   { Header: "ID", accessor: "taskId", minWidth: 90 },
   { Header: "DATE", accessor: "date", minWidth: 70 },
@@ -81,10 +80,7 @@ function getInitialState(props: DetailsComponentProps): State {
     showAllEntries: false,
     showImages: !!props.hideImagesDefault ? false : true,
     previousClaims: [],
-    numPatients: Math.max(
-      Math.ceil(patients.length * MIN_SAMPLE_FRACTION),
-      MIN_SAMPLES
-    ),
+    numPatients: Math.min(patients.length, SAMPLES_PER_PAGE),
     patients,
   };
 }
@@ -98,8 +94,6 @@ export class AuditorDetails extends React.Component<
   static contextType = SearchContext;
 
   async componentDidMount() {
-    this.props.registerActionCallback("approve", this._onApprove);
-    this.props.registerActionCallback("save", this._onApprove);
     this._loadPatientHistories();
 
     const previousClaims = await this._loadPreviousClaims(
@@ -137,28 +131,6 @@ export class AuditorDetails extends React.Component<
 
   _onShowAll = () => {
     this.setState({ showAllEntries: !this.state.showAllEntries });
-  };
-
-  _onApprove = async () => {
-    const tasks = this.props.tasks.map(task => ({
-      ...task,
-      entries: task.entries.map((entry, index) => {
-        const patientIndex = this.state.patients.findIndex(
-          patient => patient.patientId === entry.patientID
-        );
-        if (
-          (patientIndex !== -1 && patientIndex < this.state.numPatients) ||
-          this.state.showAllEntries
-        ) {
-          return {
-            ...entry,
-            reviewed: true,
-          };
-        }
-        return entry;
-      }),
-    }));
-    return { success: true, tasks };
   };
 
   _loadPatientHistories = async () => {


### PR DESCRIPTION
Fixes: https://auderenow.atlassian.net/browse/AUD-1736

Previously we marked any claim that was visible to the user as manually reviewed when the batch got reviewed. Now that we have explicit radio buttons for each claim, we use those selections to indicate if a claim was manually reviewed or not instead. Removing this old logic.

**Reviewer should merge**
* No
<!-- Delete one of the above -->
