### PR TITLE
AUD-1736 Use Maisha's postReviewNote endpoint to save claim notes

### DIFF
--- a/src/transport/maisha.ts
+++ b/src/transport/maisha.ts
@@ -204,6 +204,15 @@ export class MaishaApi {
     );
   }
 
+  async postReviewNote(body: {
+    review_note: {
+      care_pathway_instance_id: string;
+      message: string;
+    };
+  }): Promise<void> {
+    await this.fetchWithToken("/review_note", "POST", body);
+  }
+
   async fetchWithToken(
     path: string,
     method: string = "GET",

--- a/src/transport/maishaDatastore.ts
+++ b/src/transport/maishaDatastore.ts
@@ -326,7 +326,14 @@ export class RestDataStore extends DataStore {
     task: Task,
     claimIndex: number,
     notes: string
-  ): Promise<void> {}
+  ): Promise<void> {
+    await this.maishaApi.postReviewNote({
+      review_note: {
+        care_pathway_instance_id: task.id,
+        message: notes,
+      },
+    });
+  }
 }
 
 function getTaskState(


### PR DESCRIPTION
Fixes: https://auderenow.atlassian.net/browse/AUD-1736

Implement `MaishaDatastore.setClaimNotes()` by hitting their new notes endpoint.

**Reviewer should merge**
* No
<!-- Delete one of the above -->
