### PR TITLE
AUD-1736 Load claims only for selected pharmacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-pose": "^4.0.9",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.1.2",
+    "react-spinners": "^0.9.0",
     "react-table": "^6.10.3",
     "react-tabs": "^3.0.0",
     "react-tooltip": "^3.11.1",
@@ -35,6 +36,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build; git rev-list -n 1 HEAD > build/about.txt; date >> build/about.txt",
+    "deploy": "yarn build && firebase deploy --only hosting",
     "test": "react-scripts test",
     "typecheck": "tsc --noEmit",
     "eject": "react-scripts eject"

--- a/src/Components/ListItem.tsx
+++ b/src/Components/ListItem.tsx
@@ -1,40 +1,42 @@
 import "./ListItem.css";
 
+import BarLoader from "react-spinners/BarLoader";
+import { PharmacyLoadingState } from "../transport/baseDatastore";
 import React from "react";
-import { Task } from "../sharedtypes";
+import { TaskGroup } from "./TaskList";
 import { formatCurrency } from "../util/currency";
 
 export class ListItem extends React.Component<{
-  tasks: Task[];
+  tasks: TaskGroup;
   isSelected: boolean;
 }> {
   render() {
     const { tasks, isSelected } = this.props;
     const previewName = "listitem" + (isSelected ? " selected" : "");
-    const claimAmounts = tasks
-      .map(task =>
-        task.entries.map(entry => {
-          return !entry.rejected ? entry.claimedCost : 0;
-        })
-      )
-      .flat();
-    const claimsTotal = claimAmounts.reduce(
-      (sum, claimedCost) => sum + claimedCost
-    );
-    const claimCount = tasks
-      .map(task => task.entries.length)
-      .reduce((a, b) => a + b, 0);
+    const claimCount = tasks.stats
+      ? tasks.stats.claimCount
+      : tasks.tasks.map(task => task.entries.length).reduce((a, b) => a + b, 0);
+    const totalReimbursement = tasks.stats?.totalReimbursement;
+    const loading = tasks.stats?.loadingState === PharmacyLoadingState.LOADING;
     return (
-      <div className={previewName}>
-        <div className="listitem_header">
-          <span>{tasks[0].site.name}</span>
-          <span>
+      <div>
+        <div className={previewName}>
+          <div className="listitem_header">
+            <span>{tasks.site.name}</span>
+          </div>
+          <div>
             {claimCount} Claim{claimCount !== 1 ? "s" : ""}
-          </span>
+          </div>
+          {totalReimbursement !== undefined && (
+            <div>
+              Total Reimbursement:{" "}
+              <span style={{ whiteSpace: "nowrap" }}>
+                {formatCurrency(totalReimbursement)}
+              </span>
+            </div>
+          )}
         </div>
-        <div>
-          {"Total Reimbursement: " + formatCurrency(claimsTotal)}
-        </div>
+        {loading && <BarLoader css="width: auto" color="#275d5f" />}
       </div>
     );
   }

--- a/src/Screens/AuditorPanel.css
+++ b/src/Screens/AuditorPanel.css
@@ -6,3 +6,14 @@
 .claim_option {
   margin-right: 20px;
 }
+
+.auditor_pageButtons {
+  margin: 0px 5px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.auditor_pageNumber {
+  margin: auto;
+}

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -14,6 +14,7 @@ import MainChrome from "./MainChrome";
 import { OperatorDetails } from "./OperatorPanel";
 import { PayorDetails } from "./PayorPanel";
 import React from "react";
+import { TaskGroup } from "../Components/TaskList";
 import { dataStore } from "../transport/datastore";
 
 type Props = RouteComponentProps & {
@@ -35,7 +36,7 @@ const PanelComponents: {
 };
 
 const ItemComponents: {
-  [key: string]: React.ComponentType<{ tasks: Task[]; isSelected: boolean }>;
+  [key: string]: React.ComponentType<{ tasks: TaskGroup; isSelected: boolean }>;
 } = {
   default: ListItem,
 };
@@ -147,7 +148,7 @@ class MainView extends React.Component<Props, State> {
             panelElement = (
               <TaskPanel
                 config={tabConfig}
-                initialSelectedTaskID={this.props.selectedTaskID}
+                initialSelectedPharmacyID={this.props.selectedTaskID}
                 taskState={tabConfig.taskState}
                 itemComponent={ItemComponents[tabConfig.taskListComponent]}
                 detailsComponent={DetailsComponents[tabConfig.detailsComponent]}

--- a/src/Screens/PayorPanel.tsx
+++ b/src/Screens/PayorPanel.tsx
@@ -300,5 +300,5 @@ function _getReimbursementTotal(tasks: Task[]): number {
       })
     )
     .flat();
-  return claimAmounts.reduce((sum, claimedCost) => sum + claimedCost);
+  return claimAmounts.reduce((sum, claimedCost) => sum + claimedCost, 0);
 }

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -557,6 +557,7 @@ class TaskPanel extends React.Component<Props, State> {
     const { selectedPharmacyIndex } = this._getSelectedTask();
     const actionable = Object.keys(this.props.actions).length > 0;
     const notesux =
+      this.state.changes[selectedPharmacyIndex] &&
       selectedPharmacyIndex >= 0 ? (
         <Notes
           changes={this.state.changes[selectedPharmacyIndex]}

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -247,7 +247,8 @@ class TaskPanel extends React.Component<Props, State> {
   };
 
   _renderTaskListItem = (tasks: TaskGroup, isSelected: boolean) => {
-    return <this.props.itemComponent tasks={tasks} isSelected={isSelected} />;
+    const ItemComponent = this.props.itemComponent;
+    return <ItemComponent tasks={tasks} isSelected={isSelected} />;
   };
 
   _onSearchClick = () => {

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -11,6 +11,11 @@ import {
 import { DateRange, containsSearchTerm, withinDateRange } from "../util/search";
 import { DateRangePicker, FocusedInputShape } from "react-dates";
 import {
+  Flag,
+  PharmacyLoadingState,
+  PharmacyStats,
+} from "../transport/baseDatastore";
+import {
   PaymentRecord,
   Pharmacy,
   RemoteConfig,
@@ -20,18 +25,18 @@ import {
 } from "../sharedtypes";
 import React, { ChangeEvent, Fragment, ReactNode } from "react";
 import { RouteComponentProps, withRouter } from "react-router";
+import TaskList, { TaskGroup } from "../Components/TaskList";
 import moment, { Moment } from "moment";
 
 import Button from "../Components/Button";
 import CheckBox from "../Components/CheckBox";
 import ClearSearchImg from "../assets/close.png";
 import DownloadImg from "../assets/downloadcsv.png";
-import { Flag } from "../transport/baseDatastore";
 import LabelWrapper from "../Components/LabelWrapper";
 import Notes from "../Components/Notes";
+import PharmacyInfo from "../Components/PharmacyInfo";
 import { SearchContext } from "../Components/TextItem";
 import SearchIcon from "../assets/search.png";
-import TaskList from "../Components/TaskList";
 import { ToolTipIcon } from "../Components/ToolTipIcon";
 import { configuredComponent } from "../util/configuredComponent";
 import { confirmAlert } from "react-confirm-alert";
@@ -78,11 +83,11 @@ export interface DetailsComponentProps {
 
 type Props = RouteComponentProps & {
   config: TaskConfig;
-  initialSelectedTaskID?: string;
+  initialSelectedPharmacyID?: string;
   taskState: TaskState;
   listLabel: string;
   baseUrl: string;
-  itemComponent: React.ComponentType<{ tasks: Task[]; isSelected: boolean }>;
+  itemComponent: React.ComponentType<{ tasks: TaskGroup; isSelected: boolean }>;
   detailsComponent: React.ComponentType<DetailsComponentProps>;
   actions: { [key: string]: ActionConfig };
   registerForTabSelectCallback: (onTabSelect: () => boolean) => void;
@@ -98,7 +103,7 @@ type State = {
   tasks: Task[];
   flags: { [taskId: string]: Flag[] };
   changes: TaskChangeRecord[][];
-  selectedTaskIndex: number;
+  selectedPharmacyIndex: number;
   initialSelectedTaskID?: string;
   focusedInput: FocusedInputShape | null;
   searchDates: DateRange;
@@ -107,6 +112,7 @@ type State = {
   notes: string;
   disableOwnersFilter: boolean;
   cannedTaskNotes?: string[];
+  pharmacyStats: PharmacyStats;
 };
 
 class TaskPanel extends React.Component<Props, State> {
@@ -116,7 +122,7 @@ class TaskPanel extends React.Component<Props, State> {
     tasks: [],
     flags: {},
     changes: [],
-    selectedTaskIndex: -1,
+    selectedPharmacyIndex: -1,
     initialSelectedTaskID: undefined,
     focusedInput: null,
     searchDates: { startDate: null, endDate: null },
@@ -124,6 +130,7 @@ class TaskPanel extends React.Component<Props, State> {
     showSearch: false,
     notes: "",
     disableOwnersFilter: false,
+    pharmacyStats: {},
   };
   _unsubscribe = () => {};
   _inputRef: React.RefObject<HTMLInputElement> = React.createRef();
@@ -132,6 +139,10 @@ class TaskPanel extends React.Component<Props, State> {
     this._unsubscribe = dataStore.subscribeToTasks(
       this.props.taskState,
       this._onTasksChanged
+    );
+    dataStore.refreshTasks(
+      this.props.taskState,
+      this.props.initialSelectedPharmacyID
     );
     this.props.registerForTabSelectCallback(this._onTabSelect);
     this.setState({
@@ -144,27 +155,36 @@ class TaskPanel extends React.Component<Props, State> {
   }
 
   _getSelectedTask() {
-    const { selectedTaskId, selectedTaskIndex } = computeSelectedTaskId(
+    const {
+      selectedPharmacyId,
+      selectedPharmacyIndex,
+    } = computeSelectedPharmacyId(
       this._groupTasks(),
-      this.state.selectedTaskIndex,
-      this.props.initialSelectedTaskID
+      this.state.selectedPharmacyIndex,
+      this.props.initialSelectedPharmacyID
     );
-    if (selectedTaskId && this.props.initialSelectedTaskID !== selectedTaskId) {
-      this._pushHistory(selectedTaskId);
+    if (
+      selectedPharmacyId &&
+      this.props.initialSelectedPharmacyID !== selectedPharmacyId
+    ) {
+      this._pushHistory(selectedPharmacyId);
+      dataStore.refreshTasks(this.props.taskState, selectedPharmacyId);
     }
-    if (this.state.selectedTaskIndex !== selectedTaskIndex) {
-      this.setState({ selectedTaskIndex });
+    if (this.state.selectedPharmacyIndex !== selectedPharmacyIndex) {
+      this.setState({ selectedPharmacyIndex });
     }
-    return { selectedTaskIndex, selectedTaskId };
+    return { selectedPharmacyIndex, selectedPharmacyId };
   }
 
-  _onTasksChanged = async (tasks: Task[]) => {
+  _onTasksChanged = async (tasks: Task[], stats?: PharmacyStats) => {
     const changes = await Promise.all(
       tasks.map(t => dataStore.getChanges(t.id))
     );
-    let { notes, selectedTaskIndex } = this.state;
+    let { notes } = this.state;
 
-    const flags = await dataStore.loadFlags(tasks);
+    const flags = await dataStore.loadFlags(
+      tasks.filter(task => !this.state.flags[task.id])
+    );
     const sortedTasks = tasks.sort((t1, t2) => {
       const v1 = flags[t1.id] ? -1 : 0;
       const v2 = flags[t2.id] ? -1 : 0;
@@ -172,21 +192,26 @@ class TaskPanel extends React.Component<Props, State> {
     });
 
     this.setState(
-      {
+      state => ({
         allTasks: sortedTasks,
         tasks: sortedTasks,
-        flags,
+        pharmacyStats: stats || {},
+        flags: {
+          ...state.flags,
+          ...flags,
+        },
         changes,
-        selectedTaskIndex,
         notes,
-      },
+      }),
       this._updateTasks
     );
   };
 
-  _pushHistory(selectedTaskId?: string) {
+  _pushHistory(selectedPharmacyId?: string) {
     this.props.history.push(
-      `/${this.props.baseUrl}${selectedTaskId ? "/" + selectedTaskId : ""}`
+      `/${this.props.baseUrl}${
+        selectedPharmacyId ? "/" + selectedPharmacyId : ""
+      }`
     );
   }
 
@@ -207,20 +232,22 @@ class TaskPanel extends React.Component<Props, State> {
   _onTaskSelect = (index: number) => {
     const result = this._okToSwitchAway();
     if (result) {
-      const selectedTaskId =
-        index === -1 ? undefined : this._groupTasks()[index][0].id;
+      const selectedPharmacyId =
+        index === -1 ? undefined : this._groupTasks()[index].site.id;
       this.setState({
-        selectedTaskIndex: index,
+        selectedPharmacyIndex: index,
         notes: "",
       });
-      this._pushHistory(selectedTaskId);
+      this._pushHistory(selectedPharmacyId);
+      if (selectedPharmacyId) {
+        dataStore.refreshTasks(this.props.taskState, selectedPharmacyId);
+      }
     }
     return result;
   };
 
-  _renderTaskListItem = (tasks: Task[], isSelected: boolean) => {
-    const ItemComponent = this.props.itemComponent;
-    return <ItemComponent tasks={tasks} isSelected={isSelected} />;
+  _renderTaskListItem = (tasks: TaskGroup, isSelected: boolean) => {
+    return <this.props.itemComponent tasks={tasks} isSelected={isSelected} />;
   };
 
   _onSearchClick = () => {
@@ -356,7 +383,7 @@ class TaskPanel extends React.Component<Props, State> {
     this.setState({
       searchDates: { startDate: null, endDate: null },
       tasks: allTasks,
-      selectedTaskIndex: 0,
+      selectedPharmacyIndex: 0,
       searchTermGlobal: "",
       changes,
     });
@@ -505,28 +532,43 @@ class TaskPanel extends React.Component<Props, State> {
     this.setState({ notes });
   };
 
-  _groupTasks = (tasks: Task[] = this.state.tasks) => {
+  _groupTasks = (tasks: Task[] = this.state.tasks): TaskGroup[] => {
     if (this.props.config.groupTasksByPharmacy) {
-      return groupTasksByPharmacy(tasks);
+      return groupTasksByPharmacy(tasks, this.state.pharmacyStats);
     } else {
-      return tasks.map(task => [task]);
+      return tasks.map(task => ({
+        tasks: [task],
+        site: task.site,
+        stats: {
+          claimCount: task.entries.length,
+          loadingState: PharmacyLoadingState.LOADED,
+          totalReimbursement: task.entries.reduce(
+            (total, entry) => total + entry.claimedCost,
+            0
+          ),
+        },
+      }));
     }
   };
 
   render() {
     const { searchTermGlobal, notes } = this.state;
-    const { selectedTaskIndex } = this._getSelectedTask();
+    const { selectedPharmacyIndex } = this._getSelectedTask();
     const actionable = Object.keys(this.props.actions).length > 0;
     const notesux =
-      selectedTaskIndex >= 0 ? (
+      selectedPharmacyIndex >= 0 ? (
         <Notes
-          changes={this.state.changes[selectedTaskIndex]}
+          changes={this.state.changes[selectedPharmacyIndex]}
           actionable={actionable}
           notes={notes}
           onNotesChanged={this._onNotesChanged}
           cannedNotes={this.state.cannedTaskNotes}
         />
       ) : null;
+    const totalCount = Object.values(this.state.pharmacyStats).reduce(
+      (total, stat) => total + stat.claimCount,
+      0
+    );
     return (
       <SearchContext.Provider
         value={{
@@ -537,33 +579,34 @@ class TaskPanel extends React.Component<Props, State> {
           <LabelWrapper
             label={`${this.props.listLabel}:`}
             postLabelElement={
-              <span className="mainview_text_primary">{`(${this.state.tasks.length})`}</span>
+              <span className="mainview_text_primary">{`(${totalCount})`}</span>
             }
             renderLabelItems={this._renderLabelItems}
             searchPanel={this._renderSearchPanel()}
           >
             <TaskList
               onSelect={this._onTaskSelect}
-              tasks={this._groupTasks()}
+              taskGroups={this._groupTasks()}
               renderItem={this._renderTaskListItem}
-              selectedItem={selectedTaskIndex}
+              selectedItem={selectedPharmacyIndex}
               className="mainview_tasklist"
             />
           </LabelWrapper>
-          {selectedTaskIndex >= 0 && (
-            <ConfiguredDetailsWrapper
-              hideImagesDefault={this.props.hideImagesDefault}
-              showPreviousClaims={this.props.showPreviousClaims}
-              tasks={this._groupTasks()[selectedTaskIndex]}
-              flags={this.state.flags}
-              notesux={notesux}
-              notes={notes}
-              detailsComponent={this.props.detailsComponent}
-              actions={this.props.actions}
-              key={this.state.tasks[selectedTaskIndex].id}
-              taskConfig={this.props.taskConfig}
-            />
-          )}
+          {selectedPharmacyIndex >= 0 &&
+            this._groupTasks()[selectedPharmacyIndex].tasks.length > 0 && (
+              <ConfiguredDetailsWrapper
+                hideImagesDefault={this.props.hideImagesDefault}
+                showPreviousClaims={this.props.showPreviousClaims}
+                taskGroup={this._groupTasks()[selectedPharmacyIndex]}
+                flags={this.state.flags}
+                notesux={notesux}
+                notes={notes}
+                detailsComponent={this.props.detailsComponent}
+                actions={this.props.actions}
+                key={this._groupTasks()[selectedPharmacyIndex].site.id}
+                taskConfig={this.props.taskConfig}
+              />
+            )}
         </div>
       </SearchContext.Provider>
     );
@@ -573,7 +616,7 @@ class TaskPanel extends React.Component<Props, State> {
 export default withRouter(TaskPanel);
 
 interface DetailsWrapperProps {
-  tasks: Task[];
+  taskGroup: TaskGroup;
   flags: { [taskId: string]: Flag[] };
   notes: string;
   notesux: ReactNode;
@@ -646,7 +689,7 @@ class DetailsWrapper extends React.Component<
   };
 
   _countActions = () => {
-    return this.props.tasks.reduce(
+    return this.props.taskGroup.tasks.reduce(
       (stats, task) => {
         const action =
           this.state.selectedActions[task.id]?.action || "unreviewed";
@@ -665,7 +708,7 @@ class DetailsWrapper extends React.Component<
   };
 
   _performActions = async (key: string) => {
-    const tasks: Task[] = this.props.tasks;
+    const tasks: Task[] = this.props.taskGroup.tasks;
     const action = this.props.actions[key];
     const stats = this._countActions();
     const additionalReviewsNeeded =
@@ -811,10 +854,10 @@ class DetailsWrapper extends React.Component<
       <this.props.detailsComponent
         hideImagesDefault={this.props.hideImagesDefault}
         showPreviousClaims={this.props.showPreviousClaims}
-        tasks={this.props.tasks}
+        tasks={this.props.taskGroup.tasks}
         flags={this.props.flags}
         notesux={this.props.notesux}
-        key={this.props.tasks[0].id}
+        key={this.props.taskGroup.site.id}
         registerActionCallback={this._registerActionCallback}
         taskConfig={this.props.taskConfig}
         updateSelectedAction={this._updateSelectedAction}
@@ -824,7 +867,11 @@ class DetailsWrapper extends React.Component<
           {buttons.map(([key, actionConfig]) => (
             <Button
               className={actionConfig.labelClassName}
-              disabled={this.state.buttonsBusy[key]}
+              disabled={
+                this.state.buttonsBusy[key] ||
+                this.props.taskGroup.stats?.loadingState ===
+                  PharmacyLoadingState.LOADING
+              }
               label={actionConfig.label}
               labelImg={actionConfig.labelImg}
               onClick={this._onActionClick}
@@ -853,41 +900,100 @@ const ConfiguredDetailsWrapper = configuredComponent<
   return { remoteConfig: configProps };
 });
 
-const groupTasksByPharmacy = memoize((tasks: Task[]) => {
-  const tasksByPharmacy: { [pharmacyName: string]: Task[] } = {};
-  tasks.forEach(task => {
-    if (tasksByPharmacy[task.site.name]) {
-      tasksByPharmacy[task.site.name].push(task);
-    } else {
-      tasksByPharmacy[task.site.name] = [task];
-    }
-  });
-  return Object.values(tasksByPharmacy);
-});
+const firstClaimTime = (task?: Task): number => {
+  let firstTime = Number.MAX_VALUE;
+  if (!task) {
+    return firstTime;
+  }
+  task.entries.forEach(
+    claim => (firstTime = Math.min(firstTime, claim.startTime))
+  );
+  return firstTime;
+};
 
-const computeSelectedTaskId = memoize(
+const compareTasksByTime = (taskA: Task, taskB: Task): number => {
+  const timeA = firstClaimTime(taskA);
+  const timeB = firstClaimTime(taskB);
+  return timeA - timeB;
+};
+
+const groupTasksByPharmacy = memoize(
+  (tasks: Task[], pharmacyStats: PharmacyStats): TaskGroup[] => {
+    const tasksByPharmacy: { [pharmacyId: string]: TaskGroup } = {};
+    Object.entries(pharmacyStats).forEach(([pharmacyId, stats]) => {
+      tasksByPharmacy[pharmacyId] = {
+        site: stats.site,
+        tasks: [],
+        stats: {
+          claimCount: stats.claimCount,
+          loadingState: stats.loadingState,
+          totalReimbursement: stats.totalReimbursement,
+        },
+      };
+    });
+    tasks.forEach(task => {
+      if (tasksByPharmacy[task.site.id]) {
+        tasksByPharmacy[task.site.id].tasks.push(task);
+      } else {
+        tasksByPharmacy[task.site.name] = {
+          tasks: [task],
+          site: task.site,
+        };
+      }
+    });
+    Object.keys(tasksByPharmacy).forEach(
+      name =>
+        (tasksByPharmacy[name].tasks = tasksByPharmacy[name].tasks.sort(
+          compareTasksByTime
+        ))
+    );
+    return Object.values(tasksByPharmacy)
+      .filter(group => (group.stats?.claimCount || group.tasks.length) > 0)
+      .sort((groupA, groupB) => {
+        const timeA = firstClaimTime(groupA.tasks[0]);
+        const timeB = firstClaimTime(groupB.tasks[0]);
+        const dateA = new Date(timeA).toDateString();
+        const dateB = new Date(timeB).toDateString();
+        if (dateA !== dateB) {
+          // TODO: Re-enable date sorting once that gets added to the facility stats endpoint
+          // Ascending date order
+          // return timeA < timeB ? -1 : 1;
+        }
+        // Descending claim count order, if the date is the same
+        return (
+          (groupB.stats?.claimCount || groupB.tasks.length) -
+          (groupA.stats?.claimCount || groupA.tasks.length)
+        );
+      });
+  }
+);
+
+const computeSelectedPharmacyId = memoize(
   (
-    groupedTasks: Task[][],
-    selectedTaskIndex: number,
-    selectedTaskId?: string
+    groupedTasks: TaskGroup[],
+    selectedPharmacyIndex: number,
+    selectedPharmacyId?: string
   ) => {
-    let newSelectedTaskIndex;
+    let newSelectedPharmacyIndex;
     if (groupedTasks.length === 0) {
-      newSelectedTaskIndex = -1;
-      selectedTaskId = undefined;
+      newSelectedPharmacyIndex = -1;
+      selectedPharmacyId = undefined;
     } else {
-      newSelectedTaskIndex = groupedTasks.findIndex(tasks =>
-        tasks.some(task => task.id === selectedTaskId)
+      newSelectedPharmacyIndex = groupedTasks.findIndex(
+        group => group.site.id === selectedPharmacyId
       );
-      if (newSelectedTaskIndex === -1) {
-        newSelectedTaskIndex = Math.min(
-          Math.max(0, selectedTaskIndex),
+      if (newSelectedPharmacyIndex === -1) {
+        newSelectedPharmacyIndex = Math.min(
+          Math.max(0, selectedPharmacyIndex),
           groupedTasks.length - 1
         );
-        selectedTaskId = groupedTasks[newSelectedTaskIndex][0].id;
+        selectedPharmacyId = groupedTasks[newSelectedPharmacyIndex].site.id;
       }
     }
-    return { selectedTaskIndex: newSelectedTaskIndex, selectedTaskId };
+    return {
+      selectedPharmacyIndex: newSelectedPharmacyIndex,
+      selectedPharmacyId,
+    };
   }
 );
 

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -51,6 +51,7 @@ export enum UserRole {
 }
 
 export type Site = {
+  id: string;
   name: string;
   phone: string;
   location: string;

--- a/src/transport/baseDatastore.ts
+++ b/src/transport/baseDatastore.ts
@@ -3,6 +3,7 @@ import {
   PaymentRecipient,
   PaymentRecord,
   Pharmacy,
+  Site,
   Task,
   TaskChangeRecord,
   TaskState,
@@ -40,6 +41,7 @@ export enum PharmacyLoadingState {
 }
 export type PharmacyStats = {
   [pharmacyId: string]: {
+    site: Site;
     claimCount: number;
     totalReimbursement: number;
     loadingState: PharmacyLoadingState;
@@ -69,8 +71,7 @@ export abstract class DataStore {
 
   abstract subscribeToTasks(
     state: TaskState,
-    callback: (tasks: Task[], stats?: PharmacyStats) => void,
-    selectedPharmacyId?: string
+    callback: (tasks: Task[], stats?: PharmacyStats) => void
   ): () => void;
 
   abstract loadFlags(tasks: Task[]): Promise<{ [taskId: string]: Flag[] }>;
@@ -82,7 +83,7 @@ export abstract class DataStore {
   ): Promise<void>;
 
   // Optional Methods with no-op default implementations
-  refreshTasks(taskState: TaskState, pharmacyId: string): void {}
+  refreshTasks(taskState: TaskState, pharmacyId?: string): void {}
 
   async getChanges(taskID: string): Promise<TaskChangeRecord[]> {
     return [];

--- a/src/transport/baseDatastore.ts
+++ b/src/transport/baseDatastore.ts
@@ -33,6 +33,19 @@ export interface PatientHistory {
   }[];
 }
 
+export enum PharmacyLoadingState {
+  NOT_LOADED,
+  LOADING,
+  LOADED,
+}
+export type PharmacyStats = {
+  [pharmacyId: string]: {
+    claimCount: number;
+    totalReimbursement: number;
+    loadingState: PharmacyLoadingState;
+  };
+};
+
 export abstract class DataStore {
   // Required abstract methods
   abstract onAuthStateChanged(callback: (authenticated: boolean) => void): void;
@@ -56,10 +69,9 @@ export abstract class DataStore {
 
   abstract subscribeToTasks(
     state: TaskState,
-    callback: (tasks: Task[]) => void
+    callback: (tasks: Task[], stats?: PharmacyStats) => void,
+    selectedPharmacyId?: string
   ): () => void;
-
-  abstract loadTasks(taskState: TaskState): Promise<Task[]>;
 
   abstract loadFlags(tasks: Task[]): Promise<{ [taskId: string]: Flag[] }>;
 
@@ -70,6 +82,8 @@ export abstract class DataStore {
   ): Promise<void>;
 
   // Optional Methods with no-op default implementations
+  refreshTasks(taskState: TaskState, pharmacyId: string): void {}
+
   async getChanges(taskID: string): Promise<TaskChangeRecord[]> {
     return [];
   }

--- a/src/transport/maisha.ts
+++ b/src/transport/maisha.ts
@@ -122,6 +122,18 @@ export type MaishaFlagsResponse = {
   }[];
 };
 
+export type LoyaltyFacilityStatsResult = {
+  facility_stats: {
+    facility_id: string;
+    stats: {
+      approval_status: MaishaApprovalStatus;
+      payment_status: MaishaPaidStatus;
+      count: 0;
+      total_reimbursement_amount_cents: 0;
+    }[];
+  }[];
+};
+
 export class MaishaApi {
   constructor(
     readonly endpointRoot: string,
@@ -202,6 +214,10 @@ export class MaishaApi {
       `/compliance_flags/?${params.toString()}`,
       "GET"
     );
+  }
+
+  async getLoyaltyFacilityStats(): Promise<LoyaltyFacilityStatsResult> {
+    return await this.fetchWithToken("/loyalty_facility_stats");
   }
 
   async fetchWithToken(

--- a/src/transport/maisha.ts
+++ b/src/transport/maisha.ts
@@ -115,6 +115,14 @@ export type CarePathwayInstance = {
   completed_at: string;
 };
 
+export type GetCarePathwayInstancesResult = {
+  care_pathway_instances: CarePathwayInstance[];
+  count: number;
+  cursor: string;
+  has_next: boolean;
+  next_cursor: string;
+};
+
 export type MaishaFlagsResponse = {
   compliance_flags: {
     care_pathway_instance_id: string;
@@ -190,7 +198,7 @@ export class MaishaApi {
     cursor: string,
     approvalStatus?: MaishaApprovalStatus,
     paymentStatus?: MaishaPaidStatus
-  ): Promise<{ care_pathway_instances: CarePathwayInstance[] }> {
+  ): Promise<GetCarePathwayInstancesResult> {
     const params = new URLSearchParams({ cursor });
     if (approvalStatus) {
       params.append("approval_status", approvalStatus);

--- a/src/transport/maisha.ts
+++ b/src/transport/maisha.ts
@@ -1,4 +1,5 @@
 import { Flag } from "./baseDatastore";
+import { getLineAndCharacterOfPosition } from "typescript";
 
 const AUTH_STATE_KEY = "authState";
 export type AuthState = {
@@ -149,13 +150,10 @@ export class MaishaApi {
   ) {}
 
   async isLoggedIn(): Promise<boolean> {
-    try {
-      // TODO(ram): Use a status endpoint
-      await this.fetchWithToken("/facilities?loyalty_enabled=true");
-      return true;
-    } catch {
-      return false;
-    }
+    // Assume we're logged in if we have an auth state.
+    // A failed request due to expired credentials will trigger the onAuthFailed
+    // callback later, and this is faster than doing a test request
+    return this.getLocalAuthState() !== null;
   }
 
   async postLoyaltyPayment(body: {

--- a/src/transport/maishaDatastore.ts
+++ b/src/transport/maishaDatastore.ts
@@ -352,6 +352,7 @@ export class RestDataStore extends DataStore {
   ) {
     const claimFilters = this.getClaimQuery(taskState);
     if (
+      force ||
       !selectedPharmacyId ||
       !this.taskCache[taskState] ||
       (selectedPharmacyId && !this.taskCache[taskState]![selectedPharmacyId])

--- a/src/transport/maishaDatastore.ts
+++ b/src/transport/maishaDatastore.ts
@@ -358,13 +358,17 @@ export class RestDataStore extends DataStore {
       this.callTaskCallbacks(taskState);
       return;
     }
-    const pharamcyCache = this.taskCache[taskState]![selectedPharmacyId];
-    if (pharamcyCache.loadingState === PharmacyLoadingState.LOADING) {
+    const pharmacyCache = this.taskCache[taskState]![selectedPharmacyId];
+    if (!pharmacyCache) {
+      this.callTaskCallbacks(taskState);
+      return;
+    }
+    if (pharmacyCache.loadingState === PharmacyLoadingState.LOADING) {
       // No need to re-refresh
       return;
     }
-    pharamcyCache.loadingState = PharmacyLoadingState.LOADING;
-    pharamcyCache.tasks = [];
+    pharmacyCache.loadingState = PharmacyLoadingState.LOADING;
+    pharmacyCache.tasks = [];
     let cursor = "";
     let result: GetCarePathwayInstancesResult;
     do {
@@ -381,16 +385,16 @@ export class RestDataStore extends DataStore {
           createdAt: 0,
           entries: [carePathwayInstanceToClaimEntry(instance)],
           id: instance.id,
-          site: pharamcyCache.site,
+          site: pharmacyCache.site,
           state: getTaskState(
             instance.approval_status,
             instance.payment_status
           ),
         };
       });
-      pharamcyCache.tasks.push(...tasks);
+      pharmacyCache.tasks.push(...tasks);
     } while (result.has_next);
-    pharamcyCache.loadingState = PharmacyLoadingState.LOADED;
+    pharmacyCache.loadingState = PharmacyLoadingState.LOADED;
     this.callTaskCallbacks(taskState);
   }
 

--- a/src/transport/maishaDatastore.ts
+++ b/src/transport/maishaDatastore.ts
@@ -379,13 +379,16 @@ export class RestDataStore extends DataStore {
     let cursor = "";
     let result: GetCarePathwayInstancesResult;
     do {
-      this.callTaskCallbacks(taskState);
-      result = await this.maishaApi.getCarePathwayInstances(
-        selectedPharmacyId,
-        cursor,
-        claimFilters.approvalStatus,
-        claimFilters.paidStatus
-      );
+      [result] = await Promise.all([
+        // Kick off the next network request before triggering the UI update
+        this.maishaApi.getCarePathwayInstances(
+          selectedPharmacyId,
+          cursor,
+          claimFilters.approvalStatus,
+          claimFilters.paidStatus
+        ),
+        this.callTaskCallbacks(taskState),
+      ]);
       cursor = result.next_cursor;
       const tasks: Task[] = result.care_pathway_instances.map(instance => {
         return {

--- a/src/transport/maishaDatastore.ts
+++ b/src/transport/maishaDatastore.ts
@@ -137,7 +137,7 @@ export class RestDataStore extends DataStore {
         notes
       );
     }
-    await this.refreshTasks(tasks[0].state, tasks[0].site.id);
+    await this.refreshTasks(tasks[0].state, tasks[0].site.id, true);
   }
 
   async markClaimsPaid(
@@ -345,7 +345,11 @@ export class RestDataStore extends DataStore {
     this.taskCallbacks[taskState]?.forEach(cb => cb(tasks, stats));
   }
 
-  async refreshTasks(taskState: TaskState, selectedPharmacyId?: string) {
+  async refreshTasks(
+    taskState: TaskState,
+    selectedPharmacyId?: string,
+    force?: boolean
+  ) {
     const claimFilters = this.getClaimQuery(taskState);
     if (
       !selectedPharmacyId ||
@@ -363,7 +367,10 @@ export class RestDataStore extends DataStore {
       this.callTaskCallbacks(taskState);
       return;
     }
-    if (pharmacyCache.loadingState === PharmacyLoadingState.LOADING) {
+    if (
+      pharmacyCache.loadingState === PharmacyLoadingState.LOADING ||
+      (!force && pharmacyCache.loadingState === PharmacyLoadingState.LOADED)
+    ) {
       // No need to re-refresh
       return;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.5":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.6.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1197,10 +1204,46 @@
     "@emotion/utils" "0.11.2"
     "@emotion/weak-memoize" "0.2.4"
 
+"@emotion/cache@^10.0.27":
+  version "10.0.29"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
+  integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
+  dependencies:
+    "@emotion/sheet" "0.9.4"
+    "@emotion/stylis" "0.8.5"
+    "@emotion/utils" "0.11.3"
+    "@emotion/weak-memoize" "0.2.5"
+
+"@emotion/core@^10.0.15":
+  version "10.0.35"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.35.tgz#513fcf2e22cd4dfe9d3894ed138c9d7a859af9b3"
+  integrity sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
+"@emotion/css@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
+  integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
+  dependencies:
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+    babel-plugin-emotion "^10.0.27"
+
 "@emotion/hash@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
   integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
+
+"@emotion/hash@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@emotion/is-prop-valid@^0.7.3":
   version "0.7.3"
@@ -1219,6 +1262,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
   integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
 
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
 "@emotion/serialize@^0.11.12", "@emotion/serialize@^0.11.8":
   version "0.11.12"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.12.tgz#a3de660eab40e030daf2daa722fec2968a378cd4"
@@ -1230,30 +1278,66 @@
     "@emotion/utils" "0.11.2"
     csstype "^2.5.7"
 
+"@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
+  version "0.11.16"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
+  integrity sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==
+  dependencies:
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/unitless" "0.7.5"
+    "@emotion/utils" "0.11.3"
+    csstype "^2.5.7"
+
 "@emotion/sheet@0.9.3":
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.3.tgz#689f135ecf87d3c650ed0c4f5ddcbe579883564a"
   integrity sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==
+
+"@emotion/sheet@0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
+  integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
 
 "@emotion/stylis@0.8.4":
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.4.tgz#6c51afdf1dd0d73666ba09d2eb6c25c220d6fe4c"
   integrity sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==
 
+"@emotion/stylis@0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
 "@emotion/unitless@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
+
+"@emotion/unitless@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@emotion/utils@0.11.2":
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.2.tgz#713056bfdffb396b0a14f1c8f18e7b4d0d200183"
   integrity sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA==
 
+"@emotion/utils@0.11.3":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
+  integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
+
 "@emotion/weak-memoize@0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
+
+"@emotion/weak-memoize@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@firebase/app-types@0.4.3", "@firebase/app-types@0.x":
   version "0.4.3"
@@ -2685,6 +2769,22 @@ babel-plugin-emotion@^10.0.17:
     "@emotion/hash" "0.7.3"
     "@emotion/memoize" "0.7.3"
     "@emotion/serialize" "^0.11.12"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-emotion@^10.0.27:
+  version "10.0.33"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
+  integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/serialize" "^0.11.16"
     babel-plugin-macros "^2.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"
@@ -9905,6 +10005,13 @@ react-scripts@3.1.2:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.0.7"
+
+react-spinners@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.9.0.tgz#b22c38acbfce580cd6f1b04a4649e812370b1fb8"
+  integrity sha512-+x6eD8tn/aYLdxZjNW7fSR1uoAXLb9qq6TFYZR1dFweJvckcf/HfP8Pa/cy5HOvB/cvI4JgrYXTjh2Me3S6Now==
+  dependencies:
+    "@emotion/core" "^10.0.15"
 
 react-table@^6.10.3:
   version "6.10.3"


### PR DESCRIPTION
<!--
  Important: Please do not create a Pull Request without creating a Jira first.
  Also make sure to prefix the PR title with AUD-xxxx.
-->
Fixes: https://auderenow.atlassian.net/browse/AUD-1736

Rather than fetching every claim for every pharmacy up front, only load the claims for the pharmacy you've selected.


**Screenshots**

![loading](https://user-images.githubusercontent.com/1070243/96298502-66961900-0fa7-11eb-9e93-6a2a0c0be1e1.gif)

For pharmacies with >25 claims, add pagination rather than rendering all of them at once. They load in the background so you can start reviewing claims before they all load:
![loading2](https://user-images.githubusercontent.com/1070243/96298925-19667700-0fa8-11eb-9d46-799cf4a0ad6e.gif)



**Reviewer should merge**
* No
<!-- Delete one of the above -->
