### PR TITLE
Render claim notes

### DIFF
--- a/src/Components/ClaimNotes.css
+++ b/src/Components/ClaimNotes.css
@@ -13,3 +13,12 @@
   border: 1px solid var(--primary-color-dark);
   background-color: white;
 }
+
+.claimnotes_note {
+  margin: 5px;
+  border-top: 1px solid lightgray;
+}
+
+.claimnotes_note:first-child {
+  border-top: none;
+}

--- a/src/Components/ClaimNotes.tsx
+++ b/src/Components/ClaimNotes.tsx
@@ -9,12 +9,12 @@ import { dataStore } from "../transport/datastore";
 interface Props {
   claimIndex: number;
   task: Task;
-  notes: string;
+  notes: string[];
   cannedNotes: string[];
 }
 
 interface State {
-  notes: string;
+  newNote: string;
   editing: boolean;
   cannedClaimNotes?: string[];
 }
@@ -23,7 +23,7 @@ class ClaimNotes extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      notes: props.notes,
+      newNote: "",
       editing: false,
     };
   }
@@ -38,9 +38,9 @@ class ClaimNotes extends React.Component<Props, State> {
   }
 
   _onSave = async () => {
-    const { notes } = this.state;
+    const { newNote } = this.state;
     const { claimIndex, task } = this.props;
-    await dataStore.setClaimNotes(task, claimIndex, notes);
+    await dataStore.setClaimNotes(task, claimIndex, newNote);
     this.setState({ editing: false });
   };
 
@@ -49,24 +49,36 @@ class ClaimNotes extends React.Component<Props, State> {
   };
 
   _onNotesChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    this.setState({ notes: event.currentTarget.value });
+    this.setState({ newNote: event.currentTarget.value });
   };
 
   _onCannedNoteSelected = (event: ChangeEvent<HTMLSelectElement>) => {
-    const { notes } = this.state;
-    this.setState({ notes: notes + (notes ? "\n" : "") + event.target.value });
+    const { newNote } = this.state;
+    this.setState({
+      newNote: newNote + (newNote ? "\n" : "") + event.target.value,
+    });
   };
 
   render() {
-    const { notes, editing, cannedClaimNotes } = this.state;
+    const { newNote, editing, cannedClaimNotes } = this.state;
     return (
-      <div className="claimnotes_row">
+      <div>
+        {this.props.notes.length > 0 && (
+          <>
+            <div>Notes:</div>
+            <>
+              {this.props.notes.map((note: string) =>
+                note.split("\n").map(line => <div>{line}</div>)
+              )}
+            </>
+          </>
+        )}
         {editing ? (
-          <Fragment>
+          <div className="claimnotes_row">
             <textarea
               className="claimnotes_textarea"
               onChange={this._onNotesChange}
-              value={notes}
+              value={newNote}
             />
             <Button
               className="claimnotes_button"
@@ -85,16 +97,13 @@ class ClaimNotes extends React.Component<Props, State> {
                 </select>
               </div>
             )}
-          </Fragment>
+          </div>
         ) : (
-          <Fragment>
-            <span>{`Notes: ${notes}`}</span>
-            <Button
-              className="claimnotes_button"
-              label="Edit"
-              onClick={this._onEdit}
-            />
-          </Fragment>
+          <Button
+            className="claimnotes_button"
+            label="Add Note"
+            onClick={this._onEdit}
+          />
         )}
       </div>
     );

--- a/src/Components/ClaimNotes.tsx
+++ b/src/Components/ClaimNotes.tsx
@@ -70,7 +70,7 @@ class ClaimNotes extends React.Component<Props, State> {
               {this.props.notes.map((note: string) => (
                 <div className="claimnotes_note">
                   {note.split("\n").map(line => (
-                    <div>{line}</div>
+                    <p>{line}</p>
                   ))}
                 </div>
               ))}

--- a/src/Components/ClaimNotes.tsx
+++ b/src/Components/ClaimNotes.tsx
@@ -66,11 +66,15 @@ class ClaimNotes extends React.Component<Props, State> {
         {this.props.notes.length > 0 && (
           <>
             <div>Notes:</div>
-            <>
-              {this.props.notes.map((note: string) =>
-                note.split("\n").map(line => <div>{line}</div>)
-              )}
-            </>
+            <div>
+              {this.props.notes.map((note: string) => (
+                <div className="claimnotes_note">
+                  {note.split("\n").map(line => (
+                    <div>{line}</div>
+                  ))}
+                </div>
+              ))}
+            </div>
           </>
         )}
         {editing ? (

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -380,7 +380,7 @@ export class AuditorDetails extends React.Component<
                 <ClaimNotes
                   claimIndex={(claim as any).originalIndex}
                   task={this.props.tasks[task.taskIndex]}
-                  notes={claim.notes || ""}
+                  notes={claim.notes || []}
                   cannedNotes={this.props.taskConfig.cannedResponses || []}
                 />
               </React.Fragment>

--- a/src/Screens/OperatorPanel.tsx
+++ b/src/Screens/OperatorPanel.tsx
@@ -72,7 +72,7 @@ class ConfigurableOperatorDetails extends React.Component<
           <ClaimNotes
             claimIndex={(entry as any).originalIndex}
             task={this.props.tasks[index]}
-            notes={entry.notes || ""}
+            notes={entry.notes || []}
             cannedNotes={this.props.taskConfig.cannedResponses || []}
           />
         </div>

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -78,7 +78,7 @@ export type ClaimEntry = {
   startTime: number;
   endTime: number;
   reviewed?: boolean;
-  notes?: string;
+  notes?: string[];
   rejected?: boolean;
   claimID: string;
 };

--- a/src/transport/firestore.ts
+++ b/src/transport/firestore.ts
@@ -473,7 +473,7 @@ export class FirebaseDataStore extends DataStore {
   }
 
   async setClaimNotes(task: Task, claimIndex: number, notes: string) {
-    task.entries[claimIndex].notes = notes;
+    task.entries[claimIndex].notes?.push(notes);
     return await this.saveTask(task, task.id);
   }
 

--- a/src/transport/maisha.ts
+++ b/src/transport/maisha.ts
@@ -1,5 +1,4 @@
 import { Flag } from "./baseDatastore";
-import { getLineAndCharacterOfPosition } from "typescript";
 
 const AUTH_STATE_KEY = "authState";
 export type AuthState = {
@@ -108,7 +107,10 @@ export type CarePathwayInstance = {
   longitude: string;
   mpesa_till_number: string;
   name: string;
-  notes: string | null;
+  review_notes: {
+    care_pathway_instance_id: string;
+    message: string;
+  }[];
   phone_number: string;
   loyalty_sold_products?: LoyaltySoldProduct[];
   patient?: MaishaPatient;

--- a/src/transport/maishaDatastore.ts
+++ b/src/transport/maishaDatastore.ts
@@ -480,7 +480,7 @@ function carePathwayInstanceToClaimEntry(
     claimedCost: instance.facility_reimbursement_cents / 100,
     startTime: Date.parse(instance.started_at),
     endTime: Date.parse(instance.completed_at),
-    notes: instance.notes || "",
+    notes: instance.review_notes.map(note => note.message),
     claimID: instance.id,
   };
 }


### PR DESCRIPTION
Fixes: https://auderenow.atlassian.net/browse/AUD-1736

Notes is now a list, not a single string, so render it appropriately. Notes can be multiline, so I added a border between notes.

**Screenshots**
![image](https://user-images.githubusercontent.com/1070243/96323539-5c3d4480-0fd2-11eb-891a-3084dbda469c.png)


**Reviewer should merge**
* No
<!-- Delete one of the above -->
