### PR TITLE
Highlight manually created flags

### DIFF
--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -77,7 +77,7 @@ type LabeledPhoto = {
 };
 
 function getInitialState(props: DetailsComponentProps): State {
-  const patients = getPatients(props.tasks);
+  const patients = getPatients(props.tasks, props.flags);
   return {
     searchTermDetails: "",
     showAllEntries: false,
@@ -509,9 +509,9 @@ export class AuditorDetails extends React.Component<
 
   render() {
     const { searchTermGlobal } = this.context;
-    const { tasks } = this.props;
+    const { tasks, flags } = this.props;
     const { showImages } = this.state;
-    const patients = getPatients(tasks);
+    const patients = getPatients(tasks, flags);
     const showPharmacyHistory =
       defaultConfig.dataStore.type === DataStoreType.FIREBASE;
 
@@ -568,16 +568,30 @@ export class AuditorDetails extends React.Component<
   }
 }
 
-function getPatients(tasks: Task[]): PatientInfo[] {
-  return tasks.map((task, index) => ({
-    patientId: task.entries[0].patientID || "",
-    currentClaims: [
-      {
-        taskIndex: index,
-        claims: task.entries,
-      },
-    ],
-  }));
+function getPatients(
+  tasks: Task[],
+  flags: { [taskId: string]: Flag[] }
+): PatientInfo[] {
+  return tasks
+    .sort((t1, t2) => {
+      const flags1 = flags[t1.id] || [];
+      const flags2 = flags[t2.id] || [];
+      const manualFlags1 = flags1.filter(f => f.manually_flagged).length;
+      const manualFlags2 = flags2.filter(f => f.manually_flagged).length;
+      if (manualFlags1 === manualFlags2) {
+        return (flags[t2.id]?.length || 0) - (flags[t1.id]?.length || 0);
+      }
+      return manualFlags2 - manualFlags1;
+    })
+    .map((task, index) => ({
+      patientId: task.entries[0].patientID || "",
+      currentClaims: [
+        {
+          taskIndex: index,
+          claims: task.entries,
+        },
+      ],
+    }));
 }
 
 function getDateString(claim: ClaimEntry): string {

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -232,6 +232,8 @@ export class AuditorDetails extends React.Component<
       .map(group => group.claims.map(claim => this.props.flags[claim.claimID!]))
       .flat(2)
       .filter(flag => flag);
+    const manualFlags = flags.filter(flag => flag.manually_flagged);
+    const automaticFlags = flags.filter(flag => !flag.manually_flagged);
     const disabledCheckbox =
       tasks[0].state === TaskState.REJECTED ||
       tasks[0].state === TaskState.COMPLETED
@@ -261,9 +263,18 @@ export class AuditorDetails extends React.Component<
         disableScroll={true}
       >
         <div className="mainview_padded">
-          {flags.length > 0 && (
+          {manualFlags.length > 0 && (
+            <div className="mainview_row mainview_flag_box mainview_manual_flag">
+              <strong>
+                {manualFlags.map(flag => flag.description).join(", ")}
+              </strong>
+            </div>
+          )}
+          {automaticFlags.length > 0 && (
             <div className="mainview_row mainview_flag_box">
-              <strong>{flags.map(flag => flag.description).join(", ")}</strong>
+              <strong>
+                {automaticFlags.map(flag => flag.description).join(", ")}
+              </strong>
             </div>
           )}
           <div className="mainview_row">

--- a/src/Screens/MainView.css
+++ b/src/Screens/MainView.css
@@ -87,6 +87,11 @@ button:active {
   padding: 10px;
 }
 
+.mainview_manual_flag {
+  border: 1px solid darkblue;
+  background-color: lightblue;
+}
+
 .mainview_button_row {
   display: flex;
   flex-direction: row;

--- a/src/transport/baseDatastore.ts
+++ b/src/transport/baseDatastore.ts
@@ -22,7 +22,7 @@ export type ActiveTask = {
 export type Flag = {
   severity: "ALERT" | "WARN";
   description: string;
-  manual?: boolean;
+  manually_flagged: boolean;
 };
 
 export interface PatientHistory {


### PR DESCRIPTION

Fixes: https://auderenow.atlassian.net/browse/AUD-1736

Split out the patient review flag (and any other manually created flags) from the regular flags in order to highlight them. Sort claims by descending number of flags, with manual ones taking precedence.

**Screenshots**
![image](https://user-images.githubusercontent.com/1070243/96324626-9ceb8c80-0fd7-11eb-98ae-1155c59b7ebf.png)


**Reviewer should merge**
* No
<!-- Delete one of the above -->
