### PR TITLE
Group completed and rejected claims by last action

### DIFF
--- a/src/Components/LabelWrapper.tsx
+++ b/src/Components/LabelWrapper.tsx
@@ -33,7 +33,7 @@ class LabelWrapper extends Component<Props> {
       collapsed,
     } = this.props;
     return (
-      <div className={`labelwrapper_container ${className}`}>
+      <div className={`labelwrapper_container ${className || ""}`}>
         {collapsible && (
           <div
             className="labelwrapper_collapser"

--- a/src/Components/ListItem.tsx
+++ b/src/Components/ListItem.tsx
@@ -1,23 +1,23 @@
 import "./ListItem.css";
 
 import BarLoader from "react-spinners/BarLoader";
+import { ItemComponentProps } from "../Screens/TaskPanel";
 import { PharmacyLoadingState } from "../transport/baseDatastore";
 import React from "react";
-import { TaskGroup } from "./TaskList";
 import { formatCurrency } from "../util/currency";
 
-export class ListItem extends React.Component<{
-  tasks: TaskGroup;
-  isSelected: boolean;
-}> {
+export class ListItem extends React.Component<ItemComponentProps> {
   render() {
-    const { tasks, isSelected } = this.props;
+    const { tasks, isSelected, showLastModified } = this.props;
     const previewName = "listitem" + (isSelected ? " selected" : "");
     const claimCount = tasks.stats
       ? tasks.stats.claimCount
       : tasks.tasks.map(task => task.entries.length).reduce((a, b) => a + b, 0);
     const totalReimbursement = tasks.stats?.totalReimbursement;
     const loading = tasks.stats?.loadingState === PharmacyLoadingState.LOADING;
+    const lastModified = tasks.tasks
+      .flatMap(task => task.entries)
+      .reduce((date, entry) => Math.max(date, entry.lastActedTime), 0);
     return (
       <div>
         <div className={previewName}>
@@ -33,6 +33,11 @@ export class ListItem extends React.Component<{
               <span style={{ whiteSpace: "nowrap" }}>
                 {formatCurrency(totalReimbursement)}
               </span>
+            </div>
+          )}
+          {showLastModified && lastModified !== 0 && (
+            <div>
+              Last Modified: {new Date(lastModified).toLocaleDateString()}
             </div>
           )}
         </div>

--- a/src/Components/ListItem.tsx
+++ b/src/Components/ListItem.tsx
@@ -5,6 +5,7 @@ import { ItemComponentProps } from "../Screens/TaskPanel";
 import { PharmacyLoadingState } from "../transport/baseDatastore";
 import React from "react";
 import { formatCurrency } from "../util/currency";
+import { lastUpdatedTime } from "../util/tasks";
 
 export class ListItem extends React.Component<ItemComponentProps> {
   render() {
@@ -15,9 +16,7 @@ export class ListItem extends React.Component<ItemComponentProps> {
       : tasks.tasks.map(task => task.entries.length).reduce((a, b) => a + b, 0);
     const totalReimbursement = tasks.stats?.totalReimbursement;
     const loading = tasks.stats?.loadingState === PharmacyLoadingState.LOADING;
-    const lastModified = tasks.tasks
-      .flatMap(task => task.entries)
-      .reduce((date, entry) => Math.max(date, entry.lastActedTime), 0);
+    const lastModified = lastUpdatedTime(tasks.tasks);
     return (
       <div>
         <div className={previewName}>

--- a/src/Components/TaskList.css
+++ b/src/Components/TaskList.css
@@ -3,3 +3,8 @@
   outline-style: solid;
   outline-width: 4px;
 }
+
+.tasklist_wrapper {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/Components/TaskList.tsx
+++ b/src/Components/TaskList.tsx
@@ -116,7 +116,7 @@ class TaskList extends React.Component<Props, State> {
           return (
             <div
               className={activeClass}
-              key={taskGroup.site.name}
+              key={`${taskGroup.site.name}_${index}`}
               data-tip={activeDataTip}
               data-name={index}
               onClick={this._onItemPressed}

--- a/src/Screens/AuditorPanel.tsx
+++ b/src/Screens/AuditorPanel.tsx
@@ -257,7 +257,10 @@ export class AuditorDetails extends React.Component<
 
     return (
       <LabelWrapper
-        key={JSON.stringify("entry_" + patient.patientId)}
+        key={JSON.stringify(
+          "entry_" +
+            (patient.currentClaims[0]?.claims[0]?.claimID || patient.patientId)
+        )}
         disableScroll={true}
         collapsible={true}
         collapsed={this.state.collapsed[entry.claimID]}

--- a/src/Screens/MainView.tsx
+++ b/src/Screens/MainView.tsx
@@ -4,8 +4,10 @@ import "./MainView.css";
 import { AppConfig, defaultConfig, isCustomPanel } from "../store/config";
 import { RouteComponentProps, withRouter } from "react-router";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
-import { Task, UserRole } from "../sharedtypes";
-import TaskPanel, { DetailsComponentProps } from "./TaskPanel";
+import TaskPanel, {
+  DetailsComponentProps,
+  ItemComponentProps,
+} from "./TaskPanel";
 
 import AdminPanel from "./AdminPanel";
 import { AuditorDetails } from "./AuditorPanel";
@@ -14,7 +16,7 @@ import MainChrome from "./MainChrome";
 import { OperatorDetails } from "./OperatorPanel";
 import { PayorDetails } from "./PayorPanel";
 import React from "react";
-import { TaskGroup } from "../Components/TaskList";
+import { UserRole } from "../sharedtypes";
 import { dataStore } from "../transport/datastore";
 
 type Props = RouteComponentProps & {
@@ -36,7 +38,7 @@ const PanelComponents: {
 };
 
 const ItemComponents: {
-  [key: string]: React.ComponentType<{ tasks: TaskGroup; isSelected: boolean }>;
+  [key: string]: React.ComponentType<ItemComponentProps>;
 } = {
   default: ListItem,
 };

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -563,6 +563,7 @@ class TaskPanel extends React.Component<Props, State> {
     const { selectedPharmacyIndex } = this._getSelectedTask();
     const actionable = Object.keys(this.props.actions).length > 0;
     const notesux =
+      this.props.taskConfig.showBatchNotes &&
       this.state.changes[selectedPharmacyIndex] &&
       selectedPharmacyIndex >= 0 ? (
         <Notes

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -632,6 +632,7 @@ class TaskPanel extends React.Component<Props, State> {
             }
             renderLabelItems={this._renderLabelItems}
             searchPanel={this._renderSearchPanel()}
+            className="tasklist_wrapper"
           >
             <TaskList
               onSelect={this._onTaskSelect}

--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -26,6 +26,7 @@ import {
 import React, { ChangeEvent, Fragment, ReactNode } from "react";
 import { RouteComponentProps, withRouter } from "react-router";
 import TaskList, { TaskGroup } from "../Components/TaskList";
+import { lastUpdatedDate, lastUpdatedTime } from "../util/tasks";
 import moment, { Moment } from "moment";
 
 import Button from "../Components/Button";
@@ -34,7 +35,6 @@ import ClearSearchImg from "../assets/close.png";
 import DownloadImg from "../assets/downloadcsv.png";
 import LabelWrapper from "../Components/LabelWrapper";
 import Notes from "../Components/Notes";
-import PharmacyInfo from "../Components/PharmacyInfo";
 import { SearchContext } from "../Components/TextItem";
 import SearchIcon from "../assets/search.png";
 import { ToolTipIcon } from "../Components/ToolTipIcon";
@@ -81,13 +81,19 @@ export interface DetailsComponentProps {
   taskConfig: TaskConfig;
 }
 
+export interface ItemComponentProps {
+  tasks: TaskGroup;
+  isSelected: boolean;
+  showLastModified: boolean;
+}
+
 type Props = RouteComponentProps & {
   config: TaskConfig;
   initialSelectedPharmacyID?: string;
   taskState: TaskState;
   listLabel: string;
   baseUrl: string;
-  itemComponent: React.ComponentType<{ tasks: TaskGroup; isSelected: boolean }>;
+  itemComponent: React.ComponentType<ItemComponentProps>;
   detailsComponent: React.ComponentType<DetailsComponentProps>;
   actions: { [key: string]: ActionConfig };
   registerForTabSelectCallback: (onTabSelect: () => boolean) => void;
@@ -169,7 +175,10 @@ class TaskPanel extends React.Component<Props, State> {
       selectedPharmacyId &&
       this.props.initialSelectedPharmacyID !== selectedPharmacyId
     ) {
-      this._pushHistory(selectedPharmacyId);
+      const date = lastUpdatedDate(
+        this._groupTasks()[selectedPharmacyIndex].tasks
+      );
+      this._pushHistory(selectedPharmacyId, date);
       dataStore.refreshTasks(this.props.taskState, selectedPharmacyId);
     }
     if (this.state.selectedPharmacyIndex !== selectedPharmacyIndex) {
@@ -178,7 +187,21 @@ class TaskPanel extends React.Component<Props, State> {
     return { selectedPharmacyIndex, selectedPharmacyId };
   }
 
+  _tasksChangedPromise: Promise<void> | null = null;
   _onTasksChanged = async (tasks: Task[], stats?: PharmacyStats) => {
+    while (this._tasksChangedPromise) {
+      await this._tasksChangedPromise;
+    }
+    this._tasksChangedPromise = this._onTasksChangedImpl(tasks, stats);
+    await this._tasksChangedPromise;
+    this._tasksChangedPromise = null;
+  };
+
+  _onTasksChangedImpl = async (tasks: Task[], stats?: PharmacyStats) => {
+    if (tasks.length === 0 && this.props.config.groupTasksByLastAction) {
+      dataStore.refreshAllTasks(this.props.taskState);
+    }
+
     const changes = await Promise.all(
       tasks.map(t => dataStore.getChanges(t.id))
     );
@@ -209,12 +232,18 @@ class TaskPanel extends React.Component<Props, State> {
     );
   };
 
-  _pushHistory(selectedPharmacyId?: string) {
-    this.props.history.push(
-      `/${this.props.baseUrl}${
-        selectedPharmacyId ? "/" + selectedPharmacyId : ""
-      }`
-    );
+  _pushHistory(selectedPharmacyId?: string, date?: string) {
+    let name = "";
+    if (selectedPharmacyId) {
+      name = `/${selectedPharmacyId}`;
+      if (this.props.config.groupTasksByLastAction && date) {
+        name += `_${date}`;
+      }
+    }
+    const newPath = `/${this.props.baseUrl}${name}`;
+    if (newPath !== this.props.history.location.pathname) {
+      this.props.history.push(newPath);
+    }
   }
 
   _onTabSelect = (): boolean => {
@@ -235,12 +264,13 @@ class TaskPanel extends React.Component<Props, State> {
     const result = this._okToSwitchAway();
     if (result) {
       const selectedPharmacyId =
-        index === -1 ? undefined : this._groupTasks()[index].site.id;
+        index === -1 ? undefined : this._groupTasks()[index]?.site.id;
       this.setState({
         selectedPharmacyIndex: index,
         notes: "",
       });
-      this._pushHistory(selectedPharmacyId);
+      const date = lastUpdatedDate(this._groupTasks()[index].tasks);
+      this._pushHistory(selectedPharmacyId, date);
       if (selectedPharmacyId) {
         dataStore.refreshTasks(this.props.taskState, selectedPharmacyId);
       }
@@ -250,7 +280,13 @@ class TaskPanel extends React.Component<Props, State> {
 
   _renderTaskListItem = (tasks: TaskGroup, isSelected: boolean) => {
     const ItemComponent = this.props.itemComponent;
-    return <ItemComponent tasks={tasks} isSelected={isSelected} />;
+    return (
+      <ItemComponent
+        tasks={tasks}
+        isSelected={isSelected}
+        showLastModified={this.props.config.groupTasksByLastAction || false}
+      />
+    );
   };
 
   _onSearchClick = () => {
@@ -541,7 +577,11 @@ class TaskPanel extends React.Component<Props, State> {
 
   _groupTasks = (tasks: Task[] = this.state.tasks): TaskGroup[] => {
     if (this.props.config.groupTasksByPharmacy) {
-      return groupTasksByPharmacy(tasks, this.state.pharmacyStats);
+      if (this.props.config.groupTasksByLastAction) {
+        return groupTasksByPharmacyAndDate(tasks);
+      } else {
+        return groupTasksByPharmacy(tasks, this.state.pharmacyStats);
+      }
     } else {
       return tasks.map(task => ({
         tasks: [task],
@@ -1012,20 +1052,58 @@ const groupTasksByPharmacy = memoize(
   }
 );
 
+const groupTasksByPharmacyAndDate = memoize((tasks: Task[]): TaskGroup[] => {
+  const taskGroups: {
+    [pharmacyId: string]: {
+      [date: string]: TaskGroup;
+    };
+  } = {};
+  tasks.forEach(task => {
+    if (task.entries.length === 0) {
+      return;
+    }
+    const date = lastUpdatedDate([task]);
+    if (!taskGroups[task.site.id]) {
+      taskGroups[task.site.id] = {};
+    }
+    if (!taskGroups[task.site.id][date]) {
+      taskGroups[task.site.id][date] = {
+        site: task.site,
+        tasks: [],
+      };
+    }
+    taskGroups[task.site.id][date].tasks.push(task);
+  });
+  return Object.values(taskGroups).flatMap(group => Object.values(group));
+});
+
 const computeSelectedPharmacyId = memoize(
   (
     groupedTasks: TaskGroup[],
     selectedPharmacyIndex: number,
     selectedPharmacyId?: string
-  ) => {
-    let newSelectedPharmacyIndex;
+  ): { selectedPharmacyIndex: number; selectedPharmacyId?: string } => {
+    let date = "";
+    if (selectedPharmacyId?.includes("_")) {
+      [selectedPharmacyId, date] = selectedPharmacyId.split("_");
+    }
+    let newSelectedPharmacyIndex = -1;
     if (groupedTasks.length === 0) {
       newSelectedPharmacyIndex = -1;
       selectedPharmacyId = undefined;
     } else {
-      newSelectedPharmacyIndex = groupedTasks.findIndex(
-        group => group.site.id === selectedPharmacyId
-      );
+      if (date) {
+        newSelectedPharmacyIndex = groupedTasks.findIndex(
+          group =>
+            group.site.id === selectedPharmacyId &&
+            lastUpdatedDate(group.tasks) === date
+        );
+      }
+      if (newSelectedPharmacyIndex === -1) {
+        newSelectedPharmacyIndex = groupedTasks.findIndex(
+          group => group.site.id === selectedPharmacyId
+        );
+      }
       if (newSelectedPharmacyIndex === -1) {
         newSelectedPharmacyIndex = Math.min(
           Math.max(0, selectedPharmacyIndex),

--- a/src/sharedtypes.ts
+++ b/src/sharedtypes.ts
@@ -77,6 +77,7 @@ export type ClaimEntry = {
 
   startTime: number;
   endTime: number;
+  lastActedTime: number;
   reviewed?: boolean;
   notes?: string;
   rejected?: boolean;

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -35,6 +35,7 @@ export interface TaskConfig extends TabConfig {
   hideImagesDefault?: boolean;
   showPreviousClaims?: boolean;
   groupTasksByPharmacy?: boolean;
+  groupTasksByLastAction?: boolean;
   showFlagForReview?: string;
   manualReviewMinimumRatio: number;
   manualReviewMinimumNumber: number;
@@ -264,6 +265,8 @@ export const defaultConfig: AppConfig = {
       hideImagesDefault: true,
       manualReviewMinimumRatio: 0,
       manualReviewMinimumNumber: 0,
+      groupTasksByPharmacy: true,
+      groupTasksByLastAction: true,
     },
     Completed: {
       taskState: TaskState.COMPLETED,
@@ -275,6 +278,7 @@ export const defaultConfig: AppConfig = {
       baseUrl: "completed",
       hideImagesDefault: true,
       groupTasksByPharmacy: true,
+      groupTasksByLastAction: true,
       manualReviewMinimumRatio: 0,
       manualReviewMinimumNumber: 0,
     },

--- a/src/transport/baseDatastore.ts
+++ b/src/transport/baseDatastore.ts
@@ -85,6 +85,8 @@ export abstract class DataStore {
   // Optional Methods with no-op default implementations
   refreshTasks(taskState: TaskState, pharmacyId?: string): void {}
 
+  refreshAllTasks(taskState: TaskState): void {}
+
   async getChanges(taskID: string): Promise<TaskChangeRecord[]> {
     return [];
   }

--- a/src/transport/maisha.ts
+++ b/src/transport/maisha.ts
@@ -115,6 +115,8 @@ export type CarePathwayInstance = {
   patient?: MaishaPatient;
   started_at: string;
   completed_at: string;
+  last_approval_status_change_at: string | null;
+  updated_at: string;
 };
 
 export type GetCarePathwayInstancesResult = {

--- a/src/transport/maishaDatastore.ts
+++ b/src/transport/maishaDatastore.ts
@@ -233,6 +233,7 @@ export class RestDataStore extends DataStore {
     } else {
       this.taskCallbacks[state] = [callback];
     }
+    this.callTaskCallbacks(state);
     return () => {
       this.taskCallbacks[state]!.splice(
         this.taskCallbacks[state]!.indexOf(callback),
@@ -330,7 +331,7 @@ export class RestDataStore extends DataStore {
   }
 
   callTaskCallbacks(taskState: TaskState) {
-    const stateCache = this.taskCache[taskState]!;
+    const stateCache = this.taskCache[taskState] || {};
     const tasks = Object.values(stateCache).flatMap(cache => cache.tasks);
     const stats: PharmacyStats = {};
     Object.entries(stateCache).forEach(([pharmacyId, cache]) => {
@@ -343,6 +344,12 @@ export class RestDataStore extends DataStore {
       }
     });
     this.taskCallbacks[taskState]?.forEach(cb => cb(tasks, stats));
+  }
+
+  async refreshAllTasks(taskState: TaskState) {
+    Object.keys(this.taskCache[taskState] || {}).forEach(pharmacyId =>
+      this.refreshTasks(taskState, pharmacyId)
+    );
   }
 
   async refreshTasks(
@@ -404,8 +411,10 @@ export class RestDataStore extends DataStore {
         };
       });
       pharmacyCache.tasks.push(...tasks);
-    } while (result.has_next);
-    pharmacyCache.loadingState = PharmacyLoadingState.LOADED;
+    } while (result.has_next && this.taskCallbacks[taskState]?.length !== 0);
+    pharmacyCache.loadingState = result.has_next
+      ? PharmacyLoadingState.NOT_LOADED
+      : PharmacyLoadingState.LOADED;
     this.callTaskCallbacks(taskState);
   }
 
@@ -482,6 +491,9 @@ function carePathwayInstanceToClaimEntry(
     claimedCost: instance.facility_reimbursement_cents / 100,
     startTime: Date.parse(instance.started_at),
     endTime: Date.parse(instance.completed_at),
+    lastActedTime: Date.parse(
+      instance.last_approval_status_change_at || instance.updated_at
+    ),
     notes: instance.notes || "",
     claimID: instance.id,
   };

--- a/src/util/tasks.ts
+++ b/src/util/tasks.ts
@@ -1,0 +1,12 @@
+import { Task } from "../sharedtypes";
+import moment from "moment";
+
+export function lastUpdatedTime(tasks: Task[]): number {
+  return tasks
+    .flatMap(task => task.entries)
+    .reduce((date, entry) => Math.max(date, entry.lastActedTime), 0);
+}
+
+export function lastUpdatedDate(tasks: Task[]): string {
+  return moment(lastUpdatedTime(tasks)).format("YYYY-MM-DD");
+}


### PR DESCRIPTION

Fixes: https://auderenow.atlassian.net/browse/AUD-1736

Instead of just grouping by pharmacy, group by pharmacy and the date of the last action.

I had to change the path handling logic a bit in `TaskPanel` to deal with multiple groups using the same pharmacy ID, and also I have to load all the tasks in complete/rejected, because that's where the last action timestamp is.

**Screenshots**

![image](https://user-images.githubusercontent.com/1070243/96552085-23b69880-1268-11eb-8e5f-e85576fb62d6.png)