### PR TITLE
Actually flag tasks for patient review

### DIFF
--- a/src/Screens/TaskPanel.tsx
+++ b/src/Screens/TaskPanel.tsx
@@ -872,7 +872,7 @@ class DetailsWrapper extends React.Component<
       rejectAction,
       rejectedTasks,
       unreviewedTasks,
-      flaggedTasks
+      []
     );
   };
 
@@ -891,7 +891,7 @@ class DetailsWrapper extends React.Component<
     await dataStore.changeTaskState(
       tasks,
       reviewedTasks,
-      selectedClaimAction === ClaimAction.APPROVE ? flaggedTasks : [],
+      flaggedTasks,
       action.nextTaskState,
       this.props.notes,
       payment


### PR DESCRIPTION
Something about the way this code was happening before was stopping
approvals from including patient review flags, so I've made it slightly
simpler to reason about by removing the ternary.
